### PR TITLE
feat!: read configuration from files via terrace-config

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -93,3 +93,6 @@ fabric.properties
 
 # Android studio 3.1+ serialized cache file
 .idea/caches/build_file_checksums.ser
+
+# Local configuration; never baked into an image.
+config.toml

--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,7 @@ fabric.properties
 
 # Android studio 3.1+ serialized cache file
 .idea/caches/build_file_checksums.ser
+
+# Local configuration. `config.toml` is the loader's default path, so a developer copy of
+# config.example.toml lands here with real credentials in it.
+config.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,12 +232,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
-name = "arraydeque"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
-
-[[package]]
 name = "async-trait"
 version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -246,6 +240,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -345,9 +348,6 @@ name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
-dependencies = [
- "serde_core",
-]
 
 [[package]]
 name = "block-buffer"
@@ -393,6 +393,12 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
 name = "bytes"
@@ -464,26 +470,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "config"
-version = "0.15.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b85f248a4de22d204ceabc6299d89d2c70fbd7f09fea53c06c852369652d8139"
-dependencies = [
- "async-trait",
- "convert_case 0.6.0",
- "json5",
- "pathdiff",
- "ron",
- "rust-ini",
- "serde-untagged",
- "serde_core",
- "serde_json",
- "toml",
- "winnow",
- "yaml-rust2",
-]
-
-[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -501,15 +487,6 @@ dependencies = [
  "getrandom 0.2.17",
  "once_cell",
  "tiny-keccak",
-]
-
-[[package]]
-name = "convert_case"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
-dependencies = [
- "unicode-segmentation",
 ]
 
 [[package]]
@@ -636,7 +613,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
- "convert_case 0.10.0",
+ "convert_case",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -707,17 +684,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "erased-serde"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
-dependencies = [
- "serde",
- "serde_core",
- "typeid",
-]
-
-[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -725,6 +691,37 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
+name = "figment"
+version = "0.10.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
+dependencies = [
+ "atomic",
+ "parking_lot",
+ "pear",
+ "serde",
+ "tempfile",
+ "toml",
+ "uncased",
+ "version_check",
+]
+
+[[package]]
+name = "file-id"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1fc6a637b6dc58414714eddd9170ff187ecb0933d4c7024d1abbd23a3cc26e9"
+dependencies = [
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -781,6 +778,15 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "futures-channel"
@@ -936,27 +942,9 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-dependencies = [
- "foldhash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
-
-[[package]]
-name = "hashlink"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
-dependencies = [
- "hashbrown 0.16.1",
-]
 
 [[package]]
 name = "hex"
@@ -1229,6 +1217,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "inlinable_string"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
+
+[[package]]
+name = "inotify"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8"
+dependencies = [
+ "bitflags",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1311,14 +1325,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "json5"
-version = "0.4.1"
+name = "kqueue"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+checksum = "8d763e5b24120b4ddf50de6c92308156765aabfbbccebf401da7cff2d70a41ea"
 dependencies = [
- "pest",
- "pest_derive",
- "serde",
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags",
+ "libc",
 ]
 
 [[package]]
@@ -1338,6 +1361,12 @@ name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1439,6 +1468,46 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-debouncer-full"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c02b49179cfebc9932238d04d6079912d26de0379328872846118a0fa0dbb302"
+dependencies = [
+ "file-id",
+ "log",
+ "notify",
+ "notify-types",
+ "walkdir",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -1705,58 +1774,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "pathdiff"
-version = "0.2.3"
+name = "pear"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+checksum = "bdeeaa00ce488657faba8ebf44ab9361f9365a97bd39ffb8a60663f57ff4b467"
+dependencies = [
+ "inlinable_string",
+ "pear_codegen",
+ "yansi",
+]
+
+[[package]]
+name = "pear_codegen"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bab5b985dc082b345f812b7df84e1bef27e7207b39e448439ba8bd69c93f147"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "pest"
-version = "2.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
-dependencies = [
- "memchr",
- "ucd-trie",
-]
-
-[[package]]
-name = "pest_derive"
-version = "2.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd"
-dependencies = [
- "pest",
- "pest_generator",
-]
-
-[[package]]
-name = "pest_generator"
-version = "2.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6"
-dependencies = [
- "pest",
- "pest_meta",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "pest_meta"
-version = "2.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
-dependencies = [
- "pest",
-]
 
 [[package]]
 name = "pin-project"
@@ -1821,6 +1865,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "version_check",
+ "yansi",
 ]
 
 [[package]]
@@ -2106,20 +2163,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ron"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81116b9531d61eabc41aeb228e4b6b2435bcca3233b98cf3b3077d4e6e9debb3"
-dependencies = [
- "bitflags",
- "once_cell",
- "serde",
- "serde_derive",
- "typeid",
- "unicode-ident",
-]
-
-[[package]]
 name = "rust-ini"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2182,6 +2225,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2279,16 +2335,18 @@ version = "0.3.24"
 dependencies = [
  "actix-web",
  "anyhow",
- "config",
  "derive-new",
+ "figment",
  "getset",
  "rust-s3",
  "secrecy",
  "sentry",
  "serde",
+ "terrace-config",
  "thiserror",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "tracing",
  "tracing-actix-web",
  "tracing-subscriber",
@@ -2486,18 +2544,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-untagged"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9faf48a4a2d2693be24c6289dbe26552776eb7737074e6722891fadbe6c5058"
-dependencies = [
- "erased-serde",
- "serde",
- "serde_core",
- "typeid",
-]
-
-[[package]]
 name = "serde_core"
 version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2532,11 +2578,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.1.1"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
- "serde_core",
+ "serde",
 ]
 
 [[package]]
@@ -2710,6 +2756,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "terrace-config"
+version = "0.2.0"
+source = "git+https://github.com/TimSchoenle/terrace-config?tag=v0.2.0#46d924c25af6a0e67f657686f996539482e8abe3"
+dependencies = [
+ "figment",
+ "notify",
+ "notify-debouncer-full",
+ "serde",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2867,34 +2941,44 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.4+spec-1.1.0"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
- "serde_core",
+ "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_parser",
- "winnow",
+ "toml_edit",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "1.1.1+spec-1.1.0"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
- "serde_core",
+ "serde",
 ]
 
 [[package]]
-name = "toml_parser"
-version = "1.1.3+spec-1.1.0"
+name = "toml_edit"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -3019,22 +3103,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "typeid"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
-
-[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uname"
@@ -3043,6 +3115,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "uncased"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]
@@ -3431,7 +3512,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -3449,14 +3539,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -3475,10 +3582,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3487,10 +3606,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3499,10 +3630,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3511,16 +3654,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winnow"
-version = "1.0.4"
+name = "windows_x86_64_msvc"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
@@ -3538,15 +3693,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
-name = "yaml-rust2"
-version = "0.11.0"
+name = "yansi"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "631a50d867fafb7093e709d75aaee9e0e0d5deb934021fcea25ac2fe09edc51e"
-dependencies = [
- "arraydeque",
- "encoding_rs",
- "hashlink",
-]
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,23 @@ anyhow = { version = "1.0.86", features = ["backtrace"] }
 thiserror = "2.0.0"
 actix-web = { version = "4.9.0", default-features = false, features = ["macros", "compress-brotli", "compress-gzip", "cookies"] } # Guessed features, but safer to stick to default if unsure. Reverting to default for actix-web to avoid breakage unless specified.
 tracing-actix-web = "0.7.12"
-config = "0.15.0"
 serde = "1.0.209"
 rust-s3 = { version = "0.37.1", default-features = false, features = ["tokio-rustls-tls"] }
 sentry = { version = "0.48.0", default-features = false, features = ["anyhow", "debug-images", "backtrace", "contexts", "panic", "rustls"] }
 secrecy = { version = "0.10.3", features = ["serde"] }
+# The layered configuration loader: struct defaults, TOML, environment, mounted secrets, and
+# the supervisor that rebuilds the service when a mounted secret is rotated. Pinned by tag
+# rather than a branch so a version change is visible in review.
+# `full` — the loader alone would leave a rotated S3 credential unseen until the pod restarts.
+terrace-config = { git = "https://github.com/TimSchoenle/terrace-config", tag = "v0.2.0", default-features = false, features = ["full"] }
+# `CancellationToken`, the shutdown/reload signal the supervisor and the listener share.
+tokio-util = "0.7.19"
+
+[dev-dependencies]
+# `figment::Jail` is how the loader tests set `S3_PERMA_LINK_*` and write config files without
+# touching the real environment. The loader itself reaches figment through `terrace-config`;
+# this entry exists to switch on figment's `test` feature.
+figment = { version = "0.10", features = ["toml", "env", "test"] }
 
 [profile.release]
 lto = true

--- a/README.md
+++ b/README.md
@@ -28,19 +28,57 @@ A simple web server to allow pre-defined urls to always access specific S3 bucke
 
 - [Helm chart](https://github.com/TimSchoenle/helm-charts/tree/main/charts/s3-bucket-perma-link)
 
-### Environment variables
+### Configuration
 
-| Environment    	    | Required 	  | Description                         	                                             | Example                                       |
-|---------------------|-------------|-----------------------------------------------------------------------------------|-----------------------------------------------|
-| S3.ACCESS_KEY  	    | X	          | S3 Access key                        	                                            | e25a2fd93e1049a4bb48d00907d6f4bf.access       |
-| S3.SECRET_KEY    	  | X         	 | S3 secret key                     	                                               | a5990007b7a54f83b52594a86c4d520e              |
-| S3.HOST    	        | X	          | S3 host url                            	                                          | s3.amazon.com                                 |
-| S3.REGION   	       | X	          | S3 region                          	                                              | eu-central-1                                  |
-| BUCKET.ENTRIES      | X           | Key to bucket file                                                                | key:bucket,file.txt; key2:bucket2,config.yaml |
-| SERVER.HOST 	       | 	           | Server host [Default: 0.0.0.0]	                                                   | 0.0.0.0                                       |
-| SERVER.PORT       	 | 	           | Server port [Default: 8080]                           	                           | 9090                                          |
-| SENTRY_DSN     	    | 	           | Sentry DSN                          	                                             |                                               |
-| LOG_LEVEL  	        | 	           | Log level [FATAL, ERROR, WARN, INFO, DEBUG, TRACE, ALL]                         	 | INFO                                          |
+Configuration is layered, via [terrace-config](https://github.com/TimSchoenle/terrace-config).
+Lowest precedence first:
+
+1. Built-in defaults.
+2. TOML at `$S3_PERMA_LINK_CONFIG` — a file, or a directory whose `*.toml` files are merged in
+   name order. Defaults to `config.toml` in the working directory.
+3. `S3_PERMA_LINK_`-prefixed environment variables, `__` separating nesting levels.
+4. `$S3_PERMA_LINK_SECRETS_DIR` — a directory of key-named files, which is what a Kubernetes
+   `Secret` volume looks like. File name `s3__secret_key` sets `s3.secret_key`.
+5. `S3_PERMA_LINK_<KEY>_FILE` — one key, read from the file the variable names.
+
+The last three are **mutually exclusive per key**: a key supplied by two of them fails the boot
+rather than being resolved by precedence, because a stale environment variable silently
+outranking a rotated mounted secret is how a service keeps serving on a credential its operator
+believes they replaced.
+
+Mounted files are watched. When one changes, the service rebuilds its bucket clients and
+listener in place — a rotated S3 credential needs no restart. `telemetry.*` is the exception:
+the log subscriber and the Sentry client are installed once and still need one.
+
+See [config.example.toml](config.example.toml) for a complete file.
+
+| Key                   | Required | Environment variable                    | Description                                    | Example                                  |
+|-----------------------|----------|-----------------------------------------|------------------------------------------------|------------------------------------------|
+| `s3.access_key`       | X        | `S3_PERMA_LINK_S3__ACCESS_KEY`          | S3 access key                                  | `e25a2fd93e1049a4bb48d00907d6f4bf.access` |
+| `s3.secret_key`       | X        | `S3_PERMA_LINK_S3__SECRET_KEY`          | S3 secret key                                  | `a5990007b7a54f83b52594a86c4d520e`       |
+| `s3.host`             | X        | `S3_PERMA_LINK_S3__HOST`                | S3 endpoint                                    | `s3.amazon.com`                          |
+| `s3.region`           | X        | `S3_PERMA_LINK_S3__REGION`              | S3 region                                      | `eu-central-1`                           |
+| `bucket.entries`      | X        | see below                               | Request path to bucket and object key          | see below                                |
+| `server.host`         |          | `S3_PERMA_LINK_SERVER__HOST`            | Listen address [default: `0.0.0.0`]            | `0.0.0.0`                                |
+| `server.port`         |          | `S3_PERMA_LINK_SERVER__PORT`            | Listen port [default: `8080`]                  | `9090`                                   |
+| `telemetry.log_level` |          | `S3_PERMA_LINK_TELEMETRY__LOG_LEVEL`    | `trace`/`debug`/`info`/`warn`/`error` [default: `info`] | `info`                          |
+| `telemetry.sentry_dsn`|          | `S3_PERMA_LINK_TELEMETRY__SENTRY_DSN`   | Sentry DSN; absent disables Sentry             |                                          |
+
+`bucket.entries` is a table keyed by request path:
+
+```toml
+[bucket.entries."docs/handbook"]
+bucket = "media"
+object = "handbook.pdf"
+```
+
+The same through the environment, one variable per field — note that the environment layer
+lowercases keys, so a path with uppercase or `-` in it has to come from the TOML layer:
+
+```
+S3_PERMA_LINK_BUCKET__ENTRIES__CHANGELOG__BUCKET=media
+S3_PERMA_LINK_BUCKET__ENTRIES__CHANGELOG__OBJECT=releases/CHANGELOG.md
+```
 
 ## License
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,0 +1,40 @@
+# Example configuration.
+#
+# Copy to `config.toml` next to the binary, or point `S3_PERMA_LINK_CONFIG` at it (a file, or a
+# directory whose `*.toml` files are merged in name order).
+#
+# Do not put credentials in here on a real deployment. Mount them instead: every key below can
+# come from a file, which is what lets a rotated credential be picked up without a restart.
+#
+#   S3_PERMA_LINK_SECRETS_DIR=/etc/s3-perma-link/secrets  -> one file per key, named
+#                                                            `s3__secret_key`, `s3__access_key`,
+#                                                            ... (`__` separates nesting levels)
+#   S3_PERMA_LINK_S3__SECRET_KEY_FILE=/run/secrets/s3_key -> one key, from the named file
+#
+# A key supplied by two of {environment, secrets directory, `_FILE`} fails the boot rather than
+# being resolved by precedence: a stale environment variable silently outranking a rotated
+# mounted secret is exactly the failure the file layers exist to remove.
+
+[server]
+host = "0.0.0.0"
+port = 8080
+
+[s3]
+host = "s3.eu-central-1.amazonaws.com"
+region = "eu-central-1"
+access_key = "mount-me-instead"
+secret_key = "mount-me-instead"
+
+# One block per permanent link. The table key is the request path, so this entry serves
+# `GET /docs/handbook`.
+[bucket.entries."docs/handbook"]
+bucket = "media"
+object = "handbook.pdf"
+
+[bucket.entries.changelog]
+bucket = "media"
+object = "releases/CHANGELOG.md"
+
+[telemetry]
+log_level = "info"
+# sentry_dsn = "mount-me-instead"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,63 +1,144 @@
-use derive_new::new;
+//! The typed configuration surface, and the dialect of the layered loader it is read through.
+//!
+//! The layering is [`terrace_config`]'s. Lowest precedence first: struct defaults, TOML at
+//! `$S3_PERMA_LINK_CONFIG` (`config.toml` in the working directory when unset),
+//! `S3_PERMA_LINK_`-prefixed `__`-nested environment variables, `$S3_PERMA_LINK_SECRETS_DIR`,
+//! and `S3_PERMA_LINK_<KEY>_FILE` indirection. See [`loader`] for the details.
+//!
+//! Call [`load_watched`] rather than [`load`] when the process should be able to pick the
+//! configuration up again after a mounted file changes.
+
+mod loader;
+
 use s3::creds::Credentials;
 use s3::{Bucket, Region};
 use secrecy::{ExposeSecret, SecretString};
-use serde::{Deserialize, Deserializer};
+use serde::Deserialize;
 use std::collections::HashMap;
+use std::str::FromStr;
+use tracing::Level;
 
 use crate::error::Error;
 
+pub use loader::{ConfigError, Loaded, Sources, load, load_watched, terrace};
+
 const DEFAULT_SERVER_HOST: &str = "0.0.0.0";
 const DEFAULT_SERVER_PORT: u16 = 8080;
+const DEFAULT_LOG_LEVEL: &str = "info";
 
-#[derive(Debug, serde::Deserialize, Getters)]
+/// Everything the service reads at boot.
+#[derive(Debug, Deserialize, Getters)]
 #[getset(get = "pub")]
 pub struct Config {
+    #[serde(default)]
     server: ServerConfig,
     s3: S3Config,
     bucket: BucketConfig,
+    #[serde(default)]
+    telemetry: TelemetryConfig,
 }
 
-#[derive(Debug, serde::Deserialize, Getters)]
+/// Where the object store lives and how to authenticate against it.
+#[derive(Debug, Deserialize, Getters)]
 #[getset(get = "pub")]
 pub struct S3Config {
+    /// A [`SecretString`]: this struct is nested inside a [`Config`] that the reload supervisor
+    /// logs, and a credential must not be one `{:?}` away from the log stream.
     access_key: SecretString,
     secret_key: SecretString,
+    /// The endpoint, e.g. `s3.eu-central-1.amazonaws.com`.
     host: String,
     region: String,
 }
 
-#[derive(Debug, serde::Deserialize, Getters)]
+/// The listener the service binds.
+#[derive(Debug, Deserialize, Getters)]
 #[getset(get = "pub")]
 pub struct ServerConfig {
+    #[serde(default = "ServerConfig::default_host")]
     host: String,
+    #[serde(default = "ServerConfig::default_port")]
     port: u16,
 }
 
-#[derive(Debug, serde::Deserialize, Getters)]
+/// The routes the service serves, and the object each one resolves to.
+#[derive(Debug, Deserialize, Getters)]
 #[getset(get = "pub")]
 pub struct BucketConfig {
-    #[serde(deserialize_with = "deserialize_buckets_from_string")]
+    /// Request path to object. A table rather than the delimiter-separated string this used to
+    /// be: the string existed only because an environment variable cannot carry a map, and the
+    /// TOML layer can.
     entries: HashMap<String, BucketEntry>,
 }
 
-#[derive(Debug, Clone, serde::Deserialize, Getters, new)]
+/// One route's object.
+#[derive(Debug, Clone, Deserialize, Getters)]
 #[getset(get = "pub")]
 pub struct BucketEntry {
     bucket: String,
-    file: String,
+    /// The object key inside [`Self::bucket`].
+    ///
+    /// Named `object` rather than `file`, which the loader cannot express: `_FILE` is the
+    /// suffix marking file indirection, so `S3_PERMA_LINK_BUCKET__ENTRIES__DOCS__FILE` would be
+    /// read as "the value of this key is in the file named by this variable".
+    object: String,
 }
 
-impl Config {
-    pub fn get_configuration() -> crate::Result<Self> {
-        config::Config::builder()
-            .add_source(config::Environment::default().try_parsing(true))
-            .set_default("server.host", DEFAULT_SERVER_HOST)?
-            .set_default("server.port", DEFAULT_SERVER_PORT)?
-            .build()
-            .map_err(|e| Error::custom(format!("Can't parse config: {e}")))?
-            .try_deserialize::<Config>()
-            .map_err(|e| Error::custom(format!("Failed to deserialize configuration: {e}")))
+/// Logging and error reporting.
+///
+/// Both are installed once, before the reload supervisor is reached, and cannot be reinstalled
+/// on a running process — so this is the one block a configuration reload does not apply.
+#[derive(Debug, Deserialize, Getters)]
+#[getset(get = "pub")]
+pub struct TelemetryConfig {
+    /// `trace`, `debug`, `info`, `warn` or `error`. Parsed by [`Self::level`].
+    #[serde(default = "TelemetryConfig::default_log_level")]
+    log_level: String,
+    /// Absent disables Sentry entirely. A [`SecretString`]: a DSN is a write credential for
+    /// the project it names.
+    #[serde(default)]
+    sentry_dsn: Option<SecretString>,
+}
+
+impl ServerConfig {
+    fn default_host() -> String {
+        DEFAULT_SERVER_HOST.to_string()
+    }
+
+    fn default_port() -> u16 {
+        DEFAULT_SERVER_PORT
+    }
+}
+
+impl Default for ServerConfig {
+    fn default() -> Self {
+        Self {
+            host: Self::default_host(),
+            port: Self::default_port(),
+        }
+    }
+}
+
+impl TelemetryConfig {
+    fn default_log_level() -> String {
+        DEFAULT_LOG_LEVEL.to_string()
+    }
+
+    /// The configured level.
+    ///
+    /// # Errors
+    /// Returns [`Error::Logger`] if [`Self::log_level`] does not name a level.
+    pub fn level(&self) -> crate::Result<Level> {
+        Ok(Level::from_str(&self.log_level)?)
+    }
+}
+
+impl Default for TelemetryConfig {
+    fn default() -> Self {
+        Self {
+            log_level: Self::default_log_level(),
+            sentry_dsn: None,
+        }
     }
 }
 
@@ -92,47 +173,4 @@ impl S3Config {
 
         Ok(buckets)
     }
-}
-pub fn deserialize_buckets_from_string<'de, D>(
-    deserializer: D,
-) -> Result<HashMap<String, BucketEntry>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let string: String = Deserialize::deserialize(deserializer)?;
-
-    let values: Result<HashMap<String, BucketEntry>, D::Error> = string
-        .split("; ")
-        .map(|s| {
-            let mut split = s.split(':');
-
-            let identifier = match split.next() {
-                Some(s) => Ok(s),
-                None => Err(serde::de::Error::custom("Identifier is missing")),
-            }?;
-
-            let bucket_data = match split.next() {
-                Some(s) => Ok(s),
-                None => Err(serde::de::Error::custom("BucketData is missing")),
-            }?;
-
-            let mut raw_bucket_entry = bucket_data.split(',');
-
-            let bucket = match raw_bucket_entry.next() {
-                Some(s) => Ok(s),
-                None => Err(serde::de::Error::custom("Bucket is missing")),
-            }?;
-            let file = match raw_bucket_entry.next() {
-                Some(s) => Ok(s),
-                None => Err(serde::de::Error::custom("Bucket file is missing")),
-            }?;
-
-            Ok((
-                identifier.to_string(),
-                BucketEntry::new(bucket.to_string(), file.to_string()),
-            ))
-        })
-        .collect();
-
-    values
 }

--- a/src/config/loader.rs
+++ b/src/config/loader.rs
@@ -1,0 +1,254 @@
+//! The `s3-bucket-perma-link` dialect of [`terrace_config`].
+//!
+//! The layering itself — the TOML fragments, the `S3_PERMA_LINK_*` environment layer, the
+//! secrets-directory provider, the `_FILE` indirection and the shadow-key rejection — belongs
+//! to `terrace-config`. What stays here is the one thing that is ours: which environment names
+//! this deployment spells.
+
+use serde::de::DeserializeOwned;
+use terrace_config::Terrace;
+
+pub use terrace_config::{Error as ConfigError, Loaded, Sources};
+
+/// The prefix every configuration variable carries.
+const PREFIX: &str = "S3_PERMA_LINK_";
+
+/// The loader the service boots through.
+///
+/// Layers, lowest precedence first: struct defaults, TOML at `$S3_PERMA_LINK_CONFIG` (a file,
+/// or every `*.toml` in it if it names a directory, falling back to `config.toml` in the
+/// working directory), `S3_PERMA_LINK_`-prefixed `__`-nested environment variables,
+/// `$S3_PERMA_LINK_SECRETS_DIR`, and `S3_PERMA_LINK_<KEY>_FILE` indirection. The last three are
+/// mutually exclusive per key: a key supplied by two of them is refused at boot rather than
+/// resolved by precedence, because a stale environment variable shadowing a rotated mounted
+/// secret keeps the service running on the old credential.
+///
+/// Nothing is reserved beyond `S3_PERMA_LINK_CONFIG` and `S3_PERMA_LINK_SECRETS_DIR`, which
+/// `terrace-config` reserves itself: every value this service reads, the Sentry DSN and the log
+/// level included, is read out of the layers rather than out of the environment directly, so
+/// there is no key a mounted file could supply to nobody.
+#[must_use]
+pub fn terrace() -> Terrace {
+    Terrace::new(PREFIX)
+}
+
+/// Load a typed config.
+///
+/// # Errors
+/// Returns [`ConfigError`] if a required value is missing, a value fails to parse, a
+/// file-backed source cannot be read, or one key is supplied by more than one of the last
+/// three layers.
+pub fn load<T: DeserializeOwned>() -> Result<T, ConfigError> {
+    terrace().load()
+}
+
+/// Load a typed config and everything a reload needs to load it again.
+///
+/// # Errors
+/// As [`load`].
+pub fn load_watched<T: DeserializeOwned>() -> Result<Loaded<T>, ConfigError> {
+    terrace().load_watched()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::load;
+    use crate::config::Config;
+    use secrecy::ExposeSecret;
+
+    /// Set the two S3 credentials every load needs, so a test can say only what it is about.
+    fn set_credentials(jail: &mut figment::Jail) {
+        jail.set_env("S3_PERMA_LINK_S3__ACCESS_KEY", "access");
+        jail.set_env("S3_PERMA_LINK_S3__SECRET_KEY", "secret");
+        jail.set_env("S3_PERMA_LINK_S3__HOST", "s3.example.com");
+        jail.set_env("S3_PERMA_LINK_S3__REGION", "eu-central-1");
+    }
+
+    /// The dialect, end to end: the prefix, the `__` nesting, and the defaults that fill in
+    /// around what the environment supplied. `terrace-config` owns the layering and tests it;
+    /// what this pins is that the service wires it to the names an operator actually sets.
+    #[test]
+    #[expect(
+        clippy::result_large_err,
+        reason = "figment::Jail::expect_with fixes the closure's error type"
+    )]
+    fn env_overrides_and_defaults_apply() {
+        figment::Jail::expect_with(|jail| {
+            jail.clear_env();
+            set_credentials(jail);
+            jail.set_env("S3_PERMA_LINK_BUCKET__ENTRIES__docs__BUCKET", "media");
+            jail.set_env(
+                "S3_PERMA_LINK_BUCKET__ENTRIES__docs__OBJECT",
+                "handbook.pdf",
+            );
+            jail.set_env("S3_PERMA_LINK_SERVER__PORT", "9090");
+
+            let config: Config = load().map_err(|e| e.to_string()).unwrap();
+
+            // `SecretString` has no `PartialEq`; comparing requires `expose_secret()`.
+            assert_eq!(config.s3().access_key().expose_secret(), "access");
+            assert_eq!(*config.server().port(), 9090);
+            // Untouched neighbour in the same block still gets its default.
+            assert_eq!(config.server().host(), "0.0.0.0");
+            // A block untouched by the environment still materialises with its own defaults.
+            assert_eq!(config.telemetry().log_level(), "info");
+            assert!(config.telemetry().sentry_dsn().is_none());
+
+            let entry = config.bucket().entries().get("docs").expect("docs entry");
+            assert_eq!(entry.bucket(), "media");
+            assert_eq!(entry.object(), "handbook.pdf");
+            Ok(())
+        });
+    }
+
+    /// The bucket map is a real table in the TOML layer, which is the whole point of the file
+    /// layers: the entries used to be squeezed into one `key:bucket,file; ...` string because
+    /// an environment variable cannot carry a map.
+    #[test]
+    #[expect(
+        clippy::result_large_err,
+        reason = "figment::Jail::expect_with fixes the closure's error type"
+    )]
+    fn the_toml_layer_carries_the_bucket_table() {
+        figment::Jail::expect_with(|jail| {
+            jail.clear_env();
+            set_credentials(jail);
+            // No `S3_PERMA_LINK_CONFIG`: this also pins the `config.toml` fallback, which is
+            // what a container with a `ConfigMap` mounted over its working directory uses.
+            jail.create_file(
+                "config.toml",
+                r#"
+[bucket.entries.docs]
+bucket = "media"
+object = "handbook.pdf"
+
+[bucket.entries."release-notes"]
+bucket = "media"
+object = "CHANGELOG.md"
+"#,
+            )?;
+
+            let config: Config = load().map_err(|e| e.to_string()).unwrap();
+
+            assert_eq!(config.bucket().entries().len(), 2);
+            // A key an environment variable could not have spelled: the environment layer
+            // lowercases, and `-` is not expressible in a shell variable name.
+            assert_eq!(
+                config
+                    .bucket()
+                    .entries()
+                    .get("release-notes")
+                    .expect("release-notes entry")
+                    .object(),
+                "CHANGELOG.md"
+            );
+            Ok(())
+        });
+    }
+
+    /// A mounted secret outranks the TOML layer, so a `ConfigMap` carrying a placeholder key
+    /// cannot win over the `Secret` that carries the real one — through the variable names
+    /// *this* crate configures, which is the half a dependency cannot pin.
+    #[test]
+    #[expect(
+        clippy::result_large_err,
+        reason = "figment::Jail::expect_with fixes the closure's error type"
+    )]
+    fn a_secrets_directory_outranks_the_toml_layer() {
+        figment::Jail::expect_with(|jail| {
+            jail.clear_env();
+            jail.create_file(
+                "config.toml",
+                r#"
+[s3]
+access_key = "placeholder"
+secret_key = "placeholder"
+host = "s3.example.com"
+region = "eu-central-1"
+
+[bucket.entries.docs]
+bucket = "media"
+object = "handbook.pdf"
+"#,
+            )?;
+            jail.create_dir("secrets")?;
+            jail.create_file("secrets/s3__secret_key", "rotated\n")?;
+            jail.set_env(
+                "S3_PERMA_LINK_SECRETS_DIR",
+                jail.directory().join("secrets").display(),
+            );
+
+            let config: Config = load().map_err(|e| e.to_string()).unwrap();
+
+            assert_eq!(config.s3().secret_key().expose_secret(), "rotated");
+            // The key the mount said nothing about still comes from the TOML layer.
+            assert_eq!(config.s3().access_key().expose_secret(), "placeholder");
+            Ok(())
+        });
+    }
+
+    /// A single value can also be pointed at a file by name, which is the `_FILE` convention a
+    /// Docker Compose stack spells rather than mounting a whole secrets directory.
+    #[test]
+    #[expect(
+        clippy::result_large_err,
+        reason = "figment::Jail::expect_with fixes the closure's error type"
+    )]
+    fn a_file_indirection_variable_supplies_one_key() {
+        figment::Jail::expect_with(|jail| {
+            jail.clear_env();
+            // Everything but the secret, which the indirection variable supplies instead.
+            jail.set_env("S3_PERMA_LINK_S3__ACCESS_KEY", "access");
+            jail.set_env("S3_PERMA_LINK_S3__HOST", "s3.example.com");
+            jail.set_env("S3_PERMA_LINK_S3__REGION", "eu-central-1");
+            jail.set_env("S3_PERMA_LINK_BUCKET__ENTRIES__docs__BUCKET", "media");
+            jail.set_env(
+                "S3_PERMA_LINK_BUCKET__ENTRIES__docs__OBJECT",
+                "handbook.pdf",
+            );
+
+            jail.create_file("secret_key", "from-a-file\n")?;
+            // The value names the *path*; the key it fills is the one before `_FILE`.
+            jail.set_env(
+                "S3_PERMA_LINK_S3__SECRET_KEY_FILE",
+                jail.directory().join("secret_key").display(),
+            );
+
+            let config: Config = load().map_err(|e| e.to_string()).unwrap();
+
+            // Trailing newline trimmed: an editor or a `kubectl create secret --from-file`
+            // adds one, and it is not part of the credential.
+            assert_eq!(config.s3().secret_key().expose_secret(), "from-a-file");
+            Ok(())
+        });
+    }
+
+    /// One key supplied by both the environment and a mounted file fails the boot instead of
+    /// being resolved by precedence: the environment variable is the one that cannot be
+    /// rotated, so silently preferring either is how a service keeps serving on a credential
+    /// its operator believes they replaced.
+    #[test]
+    #[expect(
+        clippy::result_large_err,
+        reason = "figment::Jail::expect_with fixes the closure's error type"
+    )]
+    fn a_key_supplied_twice_is_refused() {
+        figment::Jail::expect_with(|jail| {
+            jail.clear_env();
+            set_credentials(jail);
+            jail.create_dir("secrets")?;
+            jail.create_file("secrets/s3__secret_key", "rotated")?;
+            jail.set_env(
+                "S3_PERMA_LINK_SECRETS_DIR",
+                jail.directory().join("secrets").display(),
+            );
+
+            let error = load::<Config>().expect_err("a shadowed key must fail the boot");
+            assert!(
+                error.to_string().to_lowercase().contains("secret_key"),
+                "the error must name the key: {error}"
+            );
+            Ok(())
+        });
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,8 +9,13 @@ pub enum Error {
     IoError(#[from] std::io::Error),
     #[error("Invalid route")]
     InvalidRoute(String),
-    #[error("Config error")]
-    Config(#[from] config::ConfigError),
+    // The message is carried through, unlike the variants around it: a configuration failure
+    // names the key, the file or the mount an operator has to fix, and this is also what the
+    // reload supervisor prints when a re-read fails on a service that is still serving.
+    #[error("Config error: {0}")]
+    Config(#[from] terrace_config::Error),
+    #[error("Config watch error: {0}")]
+    ConfigWatch(#[from] terrace_config::reload::WatchError),
     #[error("Bukkit error")]
     S3(#[from] s3::error::S3Error),
     #[error("{0}")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,5 +9,6 @@ pub mod data;
 pub mod error;
 mod routes;
 pub mod server;
+pub mod shutdown;
 
 pub type Result<T> = anyhow::Result<T, Error>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,49 +1,64 @@
-use s3_bucket_perma_link::config::Config;
+use s3_bucket_perma_link::config::{Config, TelemetryConfig};
 use s3_bucket_perma_link::data::DownloadData;
+use secrecy::ExposeSecret;
 use sentry::ClientInitGuard;
-use std::env;
-use std::str::FromStr;
+use std::sync::Arc;
+use tokio_util::sync::CancellationToken;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{Layer, filter};
 
-use s3_bucket_perma_link::Result;
+use s3_bucket_perma_link::error::Error;
 use s3_bucket_perma_link::server::Server;
+use s3_bucket_perma_link::{Result, config, shutdown};
 
 #[macro_use]
 extern crate tracing;
 
-const ENV_SENTRY_DSN: &str = "SENTRY_DSN";
-const ENV_LOG_LEVEL: &str = "LOG_LEVEL";
-
-const DEFAULT_LOG_LEVEL: &str = "info";
-
 #[tokio::main]
 async fn main() -> Result<()> {
-    setup_tracing()?;
+    // Before the subscriber exists, because it is the configuration that says what the
+    // subscriber should be. A failure here is returned from `main` and printed by the runtime.
+    let boot = config::load_watched::<Config>()?;
 
-    // Prevents the process from exiting until all events are sent
-    let _sentry = setup_sentry();
+    // Both are process-global and installed once, which is why `telemetry.*` is the one block
+    // a configuration reload cannot apply.
+    setup_tracing(boot.value.telemetry())?;
+    let _sentry = setup_sentry(boot.value.telemetry());
 
-    let server;
-    let download_data;
-    {
-        let config = Config::get_configuration()?;
+    let shutdown = shutdown::install();
 
-        server = Server::new(config.server().host().to_string(), *config.server().port());
-
-        let buckets = config.s3().create_buckets(config.bucket().entries())?;
-        download_data = DownloadData::new(buckets, config.bucket().entries().clone());
-    }
-
-    server.run_until_stopped(download_data).await?;
-
-    Ok(())
+    // Rebuilds the runtime whenever a mounted configuration file changes, so a rotated S3
+    // credential is picked up without restarting the pod. A reload that fails to load, or that
+    // resolves to what is already running, leaves the running service exactly as it is.
+    terrace_config::reload::run(
+        (boot.value, boot.sources),
+        &shutdown,
+        || {
+            config::load_watched::<Config>()
+                .map(|loaded| (loaded.value, loaded.sources))
+                .map_err(Error::from)
+        },
+        serve,
+    )
+    .await
 }
 
-fn setup_tracing() -> Result<()> {
-    let level = env::var(ENV_LOG_LEVEL).unwrap_or_else(|_| DEFAULT_LOG_LEVEL.to_string());
-    let level = tracing::Level::from_str(&level)?;
+/// Build and run everything a configuration change rebuilds: the bucket clients, the routing
+/// table they are looked up through, and the listener.
+///
+/// Returns when `shutdown` is cancelled — by the OS signal, or by the supervisor because the
+/// configuration changed and this runtime is being replaced.
+async fn serve(config: Arc<Config>, shutdown: CancellationToken) -> Result<()> {
+    let buckets = config.s3().create_buckets(config.bucket().entries())?;
+    let download_data = DownloadData::new(buckets, config.bucket().entries().clone());
+
+    let server = Server::new(config.server().host().to_string(), *config.server().port());
+    server.run_until_stopped(download_data, shutdown).await
+}
+
+fn setup_tracing(telemetry: &TelemetryConfig) -> Result<()> {
+    let level = telemetry.level()?;
 
     tracing_subscriber::registry()
         .with(tracing_subscriber::fmt::layer().with_filter(filter::LevelFilter::from_level(level)))
@@ -52,19 +67,18 @@ fn setup_tracing() -> Result<()> {
     Ok(())
 }
 
-fn setup_sentry() -> Option<ClientInitGuard> {
-    match env::var(ENV_SENTRY_DSN) {
-        Ok(dns) => Some(sentry::init((
-            dns,
-            sentry::ClientOptions {
-                release: sentry::release_name!(),
-                attach_stacktrace: true,
-                ..Default::default()
-            },
-        ))),
-        Err(_) => {
-            info!("{ENV_SENTRY_DSN} not set, skipping Sentry setup");
-            None
-        }
-    }
+fn setup_sentry(telemetry: &TelemetryConfig) -> Option<ClientInitGuard> {
+    let Some(dsn) = telemetry.sentry_dsn() else {
+        info!("No Sentry DSN configured, skipping Sentry setup");
+        return None;
+    };
+
+    Some(sentry::init((
+        dsn.expose_secret(),
+        sentry::ClientOptions {
+            release: sentry::release_name!(),
+            attach_stacktrace: true,
+            ..Default::default()
+        },
+    )))
 }

--- a/src/routes/download.rs
+++ b/src/routes/download.rs
@@ -17,7 +17,7 @@ async fn download(
             info!("Valid path request!");
 
             if let Some(bucket_client) = download_data.buckets().get(path.as_str()) {
-                match bucket_client.get_object_stream(bucket.file()).await {
+                match bucket_client.get_object_stream(bucket.object()).await {
                     Ok(data) => {
                         Ok(HttpResponse::Ok()
                             .streaming(data.bytes.map(|res| {

--- a/src/server.rs
+++ b/src/server.rs
@@ -3,6 +3,7 @@ use crate::data::DownloadData;
 use crate::routes::{download, health_check};
 use actix_web::{App, HttpServer, web};
 use derive_new::new;
+use tokio_util::sync::CancellationToken;
 use tracing_actix_web::TracingLogger;
 
 #[derive(new)]
@@ -12,7 +13,16 @@ pub struct Server {
 }
 
 impl Server {
-    pub async fn run_until_stopped(&self, download_data: DownloadData) -> Result<()> {
+    /// Serve until `shutdown` is cancelled.
+    ///
+    /// Returns only once the listener has released the address and in-flight requests have
+    /// drained. The reload supervisor relies on that: it builds the replacement only after this
+    /// future returns, and a replacement that raced this one would fail to bind.
+    pub async fn run_until_stopped(
+        &self,
+        download_data: DownloadData,
+        shutdown: CancellationToken,
+    ) -> Result<()> {
         info!("Starting server on {}:{}", self.host, self.port,);
 
         let download_data = web::Data::new(download_data);
@@ -23,9 +33,25 @@ impl Server {
                 .configure(health_check::get_config)
                 .configure(download::get_config)
         })
-        .bind((self.host.clone(), self.port))?;
+        // The process lifecycle belongs to `shutdown`: actix's own handler would stop this
+        // listener without telling the supervisor, which would then rebuild it and leave a
+        // service that ignored its own `SIGTERM`.
+        .disable_signals()
+        .bind((self.host.clone(), self.port))?
+        .run();
 
-        server.run().await?;
+        let handle = server.handle();
+        let stopper = tokio::spawn(async move {
+            shutdown.cancelled().await;
+            // Graceful: in-flight downloads finish before the address is released.
+            handle.stop(true).await;
+        });
+
+        let outcome = server.await;
+        // The server can also stop on its own; the waiting task would otherwise outlive it and
+        // hold the token clone until the process exits.
+        stopper.abort();
+        outcome?;
 
         Ok(())
     }

--- a/src/shutdown.rs
+++ b/src/shutdown.rs
@@ -1,0 +1,46 @@
+//! Turning the operator's stop signal into one token every task can observe.
+//!
+//! The listener no longer installs its own handler ([`Server::run_until_stopped`] disables
+//! actix's): the reload supervisor stops and rebuilds it, so the signal has to reach the
+//! supervisor rather than the listener it happens to be running.
+
+use tokio_util::sync::CancellationToken;
+
+/// Spawn the signal handler and return the token it cancels.
+///
+/// `SIGTERM` as well as `SIGINT`: `SIGTERM` is what a container runtime sends, and a service
+/// that only watches `SIGINT` is killed rather than drained on every rollout.
+#[must_use]
+pub fn install() -> CancellationToken {
+    let token = CancellationToken::new();
+    let signalled = token.clone();
+
+    tokio::spawn(async move {
+        wait_for_signal().await;
+        info!("Shutdown signal received, stopping");
+        signalled.cancel();
+    });
+
+    token
+}
+
+#[cfg(unix)]
+async fn wait_for_signal() {
+    use tokio::signal::unix::{SignalKind, signal};
+
+    // A failure here would leave the process unstoppable except by `SIGKILL`, which is worth
+    // crashing over at startup rather than discovering during a rollout.
+    let mut terminate = signal(SignalKind::terminate()).expect("SIGTERM handler can be installed");
+
+    tokio::select! {
+        _ = tokio::signal::ctrl_c() => {}
+        _ = terminate.recv() => {}
+    }
+}
+
+#[cfg(not(unix))]
+async fn wait_for_signal() {
+    // `SIGTERM` has no Windows equivalent; `ctrl_c` also covers the console close events tokio
+    // maps onto it.
+    let _ = tokio::signal::ctrl_c().await;
+}


### PR DESCRIPTION
Migrates the env-only config system to [terrace-config](https://github.com/TimSchoenle/terrace-config), the same layered loader [TankoVault](https://github.com/TimSchoenle/TankoVault) boots on.

## Why

Two things the old system could not do:

- **Rotate a credential.** Environment variables are fixed for the life of a process, so a new S3 key meant restarting the pod.
- **Express a map.** `BUCKET.ENTRIES` was one string, `key:bucket,file; key2:bucket2,file2`, parsed by a hand-written `Deserializer` — because a shell variable cannot carry a table.

## What changed

Layers, lowest precedence first: struct defaults, TOML at `$S3_PERMA_LINK_CONFIG` (`config.toml` by default), `S3_PERMA_LINK_`-prefixed `__`-nested environment variables, `$S3_PERMA_LINK_SECRETS_DIR`, and `S3_PERMA_LINK_<KEY>_FILE` indirection.

The last three are mutually exclusive per key: a key supplied by two of them **fails the boot** rather than being resolved by precedence. A stale environment variable silently outranking a rotated mounted secret is how a service keeps serving on a credential its operator believes they replaced.

Mounted files are watched. `terrace_config::reload::run` rebuilds the bucket clients and the listener in place when one changes, so a rotated S3 credential needs no restart. `telemetry.*` is the documented exception — the log subscriber and the Sentry client are process-global and installed once, before the supervisor is reached.

The listener now takes a `CancellationToken` and stops gracefully on it (`handle.stop(true)`), so in-flight downloads drain and the address is released before the replacement binds it. `SIGTERM` handling moved out of actix into `src/shutdown.rs` — actix's own handler would have stopped a listener the supervisor would then rebuild, leaving a service that ignored its own `SIGTERM`.

## Breaking changes

Every configuration key is renamed. **The Helm chart needs a matching update.**

| Before | After |
|---|---|
| `S3.ACCESS_KEY` | `S3_PERMA_LINK_S3__ACCESS_KEY` |
| `S3.SECRET_KEY` | `S3_PERMA_LINK_S3__SECRET_KEY` |
| `S3.HOST` | `S3_PERMA_LINK_S3__HOST` |
| `S3.REGION` | `S3_PERMA_LINK_S3__REGION` |
| `SERVER.HOST` | `S3_PERMA_LINK_SERVER__HOST` |
| `SERVER.PORT` | `S3_PERMA_LINK_SERVER__PORT` |
| `SENTRY_DSN` | `S3_PERMA_LINK_TELEMETRY__SENTRY_DSN` |
| `LOG_LEVEL` | `S3_PERMA_LINK_TELEMETRY__LOG_LEVEL` |
| `BUCKET.ENTRIES` (string) | `bucket.entries` (table) |

`SENTRY_DSN` and `LOG_LEVEL` moved *into* the layers rather than staying process-level reads, so the DSN — a write credential for the project it names — can be mounted rather than baked into a pod spec. Both are `SecretString`/redacted where they should be.

`bucket.entries` is now a table, and a bucket entry's `file` field is now **`object`**:

```toml
[bucket.entries."docs/handbook"]
bucket = "media"
object = "handbook.pdf"
```

The rename is not cosmetic. `_FILE` is the indirection suffix, so `S3_PERMA_LINK_BUCKET__ENTRIES__DOCS__FILE` was unspellable — the loader read it as "the value of this key is in the file this variable names" and failed the boot trying to open `handbook.pdf`. It is also the better name for an S3 object key.

Note that the environment layer lowercases keys, so a route path with uppercase or `-` in it now has to come from the TOML layer. Documented in the README.

## Prefix

`S3_PERMA_LINK_`, derived from the repo name the way `TANKOVAULT_` is from TankoVault's, dropping the redundant "bucket". Shout if you'd rather have something shorter — it is one `const` in `src/config/loader.rs`.

## Tests

Five loader tests using `figment::Jail`, pinning the half a dependency cannot: that this service wires the layering to the names an operator actually sets.

- environment overrides and per-block defaults
- the TOML layer carrying the bucket table, including the `config.toml` fallback path
- a secrets directory outranking the TOML layer
- `_FILE` indirection filling a single key
- a key supplied twice failing the boot

## Also

- `config.example.toml` documents the full surface; `config.toml` is gitignored and dockerignored so a developer copy with real credentials cannot be committed or baked into an image.
- The `config` crate is dropped.
- `Error::Config` now carries the underlying message. The old `#[error("Config error")]` discarded the one thing an operator needs — which key, file or mount to fix — and it is also what the reload supervisor prints when a re-read fails on a service that is still serving.
