### PR TITLE
feat(config): update terrace-config to 0.5.0 and generate the README from the types

### DIFF
--- a/.github/templates/README.md.hbs
+++ b/.github/templates/README.md.hbs
@@ -1,0 +1,120 @@
+<!--
+Generated from .github/templates/README.md.hbs — edit that file, not this one. CI renders it on
+every pull request and commits the result back to the branch; a push to master whose README.md
+does not match its template fails the `readme` check in .github/workflows/docs.yml.
+
+Variables come from `cargo run --example readme-variables`, which reads them off the code they
+describe:
+
+    repo, branch, build_workflow, docker_image   the repository coordinates, defined once
+    prefix, config_var, secrets_dir_var,
+    indirection_suffix                           the loader's own dialect, from src/config/loader.rs
+    loader_table, keys_table                     generated from Config, via terrace-config's
+                                                 `schema` feature
+
+That is what keeps the configuration reference honest: a key added to `Config` without a `///`
+comment shows an empty Purpose cell in the pull request that adds it, and a key removed from it
+leaves this page on the same commit.
+-->
+<br/>
+<p align="center">
+  <h3 align="center">S3 Bucket Permanent Permanent Link</h3>
+
+  <p align="center">
+    <a href="https://github.com/{{repo}}/issues">Report Bug</a>
+    .
+    <a href="https://github.com/{{repo}}/issues">Request Feature</a>
+  </p>
+</p>
+
+<div align="center">
+
+![Docker Image Version (latest semver)](https://img.shields.io/docker/v/{{docker_image}})
+![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/{{repo}}/{{build_workflow}})
+![Issues](https://img.shields.io/github/issues/{{repo}})
+[![codecov](https://codecov.io/gh/{{repo}}/branch/{{branch}}/graph/badge.svg?token=dDUZjsYmh2)](https://codecov.io/gh/{{repo}})
+![License](https://img.shields.io/github/license/{{repo}})
+[![wakatime](https://wakatime.com/badge/github/{{repo}}.svg)](https://wakatime.com/badge/github/{{repo}})
+
+</div>
+
+## About The Project
+
+A simple web server to allow pre-defined urls to always access specific S3 bucket resources.
+
+### Installation - Helm chart
+
+- [Helm chart](https://github.com/TimSchoenle/helm-charts/tree/main/charts/s3-bucket-perma-link)
+
+### Configuration
+
+Configuration is layered, via [terrace-config](https://github.com/TimSchoenle/terrace-config).
+Lowest precedence first:
+
+1. Built-in defaults.
+2. TOML at `${{config_var}}` — a file, or a directory whose `*.toml` files are merged in
+   name order. Defaults to `config.toml` in the working directory.
+3. `{{prefix}}`-prefixed environment variables, `__` separating nesting levels.
+4. `${{secrets_dir_var}}` — a directory of key-named files, which is what a Kubernetes
+   `Secret` volume looks like. File name `s3__secret_key` sets `s3.secret_key`.
+5. `{{prefix}}<KEY>{{indirection_suffix}}` — one key, read from the file the variable names.
+
+The last three are **mutually exclusive per key**: a key supplied by two of them fails the boot
+rather than being resolved by precedence, because a stale environment variable silently
+outranking a rotated mounted secret is how a service keeps serving on a credential its operator
+believes they replaced.
+
+Mounted files are watched. When one changes, the service rebuilds its bucket clients and
+listener in place — a rotated S3 credential needs no restart. `telemetry.*` is the exception:
+the log subscriber and the Sentry client are installed once and still need one.
+
+Every generation logs which layer supplied each key, so an unexpected value can be traced to the
+file or variable it came from without attaching a debugger.
+
+See [config.example.toml](config.example.toml) for a complete file.
+
+#### The variables read before the configuration exists
+
+{{loader_table}}
+#### The keys
+
+Every key below is spelled the same way in all four layers: `__` separates nesting levels and
+case is folded. `s3.secret_key` is `{{prefix}}S3__SECRET_KEY` as an environment
+variable, `{{prefix}}S3__SECRET_KEY{{indirection_suffix}}` as file indirection, and
+`s3__secret_key` as a file name inside `${{secrets_dir_var}}`.
+
+{{keys_table}}
+`bucket.entries` is one row above rather than one per link, because the key paths under it are
+route names no type knows ahead of time. Each is a table keyed by request path:
+
+```toml
+[bucket.entries."docs/handbook"]
+bucket = "media"
+object = "handbook.pdf"
+```
+
+The same through the environment, one variable per field — note that the environment layer
+lowercases keys, so a path with uppercase or `-` in it has to come from the TOML layer:
+
+```
+{{prefix}}BUCKET__ENTRIES__CHANGELOG__BUCKET=media
+{{prefix}}BUCKET__ENTRIES__CHANGELOG__OBJECT=releases/CHANGELOG.md
+```
+
+## Contributing
+
+`README.md` is generated. Edit [.github/templates/README.md.hbs](.github/templates/README.md.hbs)
+instead — CI renders it on every pull request and commits the result back to the branch, and a
+push to `{{branch}}` whose `README.md` does not match its template fails.
+
+The configuration tables in it are generated from `Config` in
+[src/config.rs](src/config.rs), so a key is documented by documenting the field:
+
+```bash
+cargo run --example config-schema -- --format markdown
+```
+
+## License
+
+See [LICENSE](https://github.com/{{repo}}/blob/{{branch}}/LICENSE) for
+more information.

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -72,6 +72,12 @@ jobs:
       name: ci
       deployment: false
     runs-on: ubuntu-latest
+    # Shared with docs.yml, which renders README.md onto the same branch. Both make verified
+    # commits through the API, and that call rejects a commit whose parent has moved — so two of
+    # them racing would leave one failing for no reason a reader could act on. They queue instead.
+    concurrency:
+      group: branch-writes-${{ github.ref }}
+      cancel-in-progress: false
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,142 @@
+name: Docs
+
+# `README.md` is generated from `.github/templates/README.md.hbs`. This workflow is what makes
+# that claim true in both directions.
+#
+# On a pull request it renders the template and commits the result to the branch, so the
+# configuration reference — every key of `Config`, its environment spelling, its default and its
+# `///` comment — is never edited by hand. The case that matters is a pull request that adds a
+# configuration key: it arrives with the documentation for that key already written, because the
+# table is read off the type in the same commit that changes it.
+#
+# Everywhere it cannot commit — a push to `master`, a pull request from a fork — it renders in
+# `check` mode instead, writing nothing and failing if the committed `README.md` is stale.
+# Without that half, editing `README.md` directly would appear to work right up until the next
+# pull request silently reverted it.
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+# Not scoped to this workflow: the auto-format job in build.yaml also commits to the pull request
+# branch, and the API call that makes a verified commit rejects one whose parent has moved. Two
+# writers racing would leave one of them failing for no reason a reader could act on, so they
+# queue instead. `cancel-in-progress: false` for the same reason — a cancelled run here means a
+# branch left holding a half-generated file.
+concurrency:
+  group: branch-writes-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions: {}
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  render:
+    name: Render
+    # Forks get no secrets, so the App token would be empty and the commit could not be pushed to
+    # their branch anyway. `check` below picks those pull requests up instead.
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Where ACTIONS_MAINTENANCE_APP_ID and ACTIONS_MAINTENANCE_PRIVATE_KEY live, as in the
+    # auto-format job of build.yaml.
+    environment:
+      name: ci
+      deployment: false
+    permissions:
+      contents: read # the write happens with the App token below, not with GITHUB_TOKEN
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      # An App installation token, so the commit is verified and — unlike one made with
+      # `GITHUB_TOKEN` — re-triggers the checks on the branch it lands on.
+      - name: Generate Bot Token
+        id: generate_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.ACTIONS_MAINTENANCE_APP_ID }}
+          private-key: ${{ secrets.ACTIONS_MAINTENANCE_PRIVATE_KEY }}
+          permission-contents: write
+
+      # The head of the branch, not the merge commit: the render has to read the `Config` the
+      # pull request proposes, and the commit has to land on top of what is there now.
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.head_ref }}
+          persist-credentials: false
+
+      - name: Install stable toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+
+      - name: Collect README variables
+        id: variables
+        run: |
+          json="$(cargo run --quiet --example readme-variables)"
+          echo "json=${json}" >> "$GITHUB_OUTPUT"
+
+      - name: Render and commit the README
+        id: readme
+        uses: TimSchoenle/actions/actions/common/render-template-and-commit@15d83f02081c9dc8a844646199c63792dcccdfa8 # tag=actions-common-render-template-and-commit-v1.1.3
+        with:
+          template: .github/templates/README.md.hbs
+          output: README.md
+          variables: ${{ steps.variables.outputs.json }}
+          token: ${{ steps.generate_token.outputs.token }}
+          commit_message: 'docs: render README from template'
+
+      - name: Summarise
+        env:
+          COMMITTED: ${{ steps.readme.outputs.changes_detected }}
+          COMMIT_URL: ${{ steps.readme.outputs.commit_url }}
+        run: |
+          if [ "${COMMITTED}" = "true" ]; then
+            echo "README.md re-rendered: ${COMMIT_URL}" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "README.md already matched its template." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+  check:
+    name: README
+    # The complement of `render`: the pushes to `master` that no pull request rendered, and the
+    # fork pull requests that could not be committed to. Between the two conditions, every event
+    # this workflow sees is handled by exactly one job.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Install stable toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+
+      - name: Collect README variables
+        id: variables
+        run: |
+          json="$(cargo run --quiet --example readme-variables)"
+          echo "json=${json}" >> "$GITHUB_OUTPUT"
+
+      # Writes nothing; fails with the first differing line when README.md is stale.
+      - name: Verify README.md is current
+        uses: TimSchoenle/actions/actions/common/render-template@3b7d152374ee63e720e7c16bed8b088b40554911 # tag=actions-common-render-template-v1.1.1
+        with:
+          template: .github/templates/README.md.hbs
+          output: README.md
+          variables: ${{ steps.variables.outputs.json }}
+          check: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2342,12 +2342,12 @@ dependencies = [
  "actix-web",
  "anyhow",
  "derive-new",
- "figment",
  "getset",
  "rust-s3",
  "secrecy",
  "sentry",
  "serde",
+ "serde_json",
  "terrace-config",
  "thiserror",
  "tokio",
@@ -2766,17 +2766,29 @@ dependencies = [
 
 [[package]]
 name = "terrace-config"
-version = "0.2.0"
-source = "git+https://github.com/TimSchoenle/terrace-config?tag=v0.2.0#46d924c25af6a0e67f657686f996539482e8abe3"
+version = "0.5.0"
+source = "git+https://github.com/TimSchoenle/terrace-config?tag=v0.5.0#b47ca70cefaf48484682a0913dbef48ba4eba10c"
 dependencies = [
  "figment",
  "notify",
  "notify-debouncer-full",
  "serde",
+ "serde_json",
+ "terrace-config-macros",
  "thiserror",
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "terrace-config-macros"
+version = "0.5.0"
+source = "git+https://github.com/TimSchoenle/terrace-config?tag=v0.5.0#b47ca70cefaf48484682a0913dbef48ba4eba10c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,23 +22,37 @@ anyhow = { version = "1.0.86", features = ["backtrace"] }
 thiserror = "2.0.0"
 actix-web = { version = "4.9.0", default-features = false, features = ["macros", "compress-brotli", "compress-gzip", "cookies"] } # Guessed features, but safer to stick to default if unsure. Reverting to default for actix-web to avoid breakage unless specified.
 tracing-actix-web = "0.7.12"
-serde = "1.0.209"
+# `derive` is declared here rather than left to feature unification: `src/config.rs` writes
+# `#[derive(Deserialize, Serialize)]`, so the crate that names it is the crate that needs it.
+serde = { version = "1.0.209", features = ["derive"] }
 rust-s3 = { version = "0.37.1", default-features = false, features = ["tokio-rustls-tls"] }
 sentry = { version = "0.48.0", default-features = false, features = ["anyhow", "debug-images", "backtrace", "contexts", "panic", "rustls"] }
 secrecy = { version = "0.10.3", features = ["serde"] }
 # The layered configuration loader: struct defaults, TOML, environment, mounted secrets, and
 # the supervisor that rebuilds the service when a mounted secret is rotated. Pinned by tag
 # rather than a branch so a version change is visible in review.
-# `full` — the loader alone would leave a rotated S3 credential unseen until the pod restarts.
-terrace-config = { git = "https://github.com/TimSchoenle/terrace-config", tag = "v0.2.0", default-features = false, features = ["full"] }
+#
+# `full` is `loader` + `reload` + `schema` + `explain`:
+#   loader  the layering itself.
+#   reload  the loader alone would leave a rotated S3 credential unseen until the pod restarts.
+#   schema  `examples/config-schema.rs` and `examples/readme-variables.rs` generate the README
+#           configuration tables from the types in `src/config.rs`, so the reference cannot drift
+#           from the code. Nothing in the binary calls it, and release LTO drops it.
+#   explain which layer supplied each key, logged once per generation in `main` — the answer to
+#           "the mounted secret is not being picked up" without attaching a debugger.
+terrace-config = { git = "https://github.com/TimSchoenle/terrace-config", tag = "v0.5.0", default-features = false, features = ["full"] }
 # `CancellationToken`, the shutdown/reload signal the supervisor and the listener share.
 tokio-util = "0.7.19"
 
 [dev-dependencies]
-# `figment::Jail` is how the loader tests set `S3_PERMA_LINK_*` and write config files without
-# touching the real environment. The loader itself reaches figment through `terrace-config`;
-# this entry exists to switch on figment's `test` feature.
-figment = { version = "=0.10.19", features = ["toml", "env", "test"] }
+# The same crate again, for its `testing` feature: the sandbox the loader tests arrange their
+# layers in. It is deliberately outside `full`, because a service image has no reason to link a
+# test harness — a dev-dependency on the same tag is how it is meant to be taken.
+terrace-config = { git = "https://github.com/TimSchoenle/terrace-config", tag = "v0.5.0", default-features = false, features = ["testing"] }
+# `examples/readme-variables.rs` assembles the README template payload. Building it here rather
+# than by hand is what makes the embedded Markdown tables safe: a `|` or a newline inside a
+# generated cell is a JSON escape, not a broken document.
+serde_json = "1.0.151"
 
 [profile.release]
 lto = true

--- a/README.md
+++ b/README.md
@@ -1,3 +1,21 @@
+<!--
+Generated from .github/templates/README.md.hbs — edit that file, not this one. CI renders it on
+every pull request and commits the result back to the branch; a push to master whose README.md
+does not match its template fails the `readme` check in .github/workflows/docs.yml.
+
+Variables come from `cargo run --example readme-variables`, which reads them off the code they
+describe:
+
+    repo, branch, build_workflow, docker_image   the repository coordinates, defined once
+    prefix, config_var, secrets_dir_var,
+    indirection_suffix                           the loader's own dialect, from src/config/loader.rs
+    loader_table, keys_table                     generated from Config, via terrace-config's
+                                                 `schema` feature
+
+That is what keeps the configuration reference honest: a key added to `Config` without a `///`
+comment shows an empty Purpose cell in the pull request that adds it, and a key removed from it
+leaves this page on the same commit.
+-->
 <br/>
 <p align="center">
   <h3 align="center">S3 Bucket Permanent Permanent Link</h3>
@@ -12,7 +30,7 @@
 <div align="center">
 
 ![Docker Image Version (latest semver)](https://img.shields.io/docker/v/timmi6790/s3-bucket-perma-link)
-![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/TimSchoenle/s3-bucket-perma-link/build.yml)
+![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/TimSchoenle/s3-bucket-perma-link/build.yaml)
 ![Issues](https://img.shields.io/github/issues/TimSchoenle/s3-bucket-perma-link)
 [![codecov](https://codecov.io/gh/TimSchoenle/s3-bucket-perma-link/branch/master/graph/badge.svg?token=dDUZjsYmh2)](https://codecov.io/gh/TimSchoenle/s3-bucket-perma-link)
 ![License](https://img.shields.io/github/license/TimSchoenle/s3-bucket-perma-link)
@@ -50,21 +68,39 @@ Mounted files are watched. When one changes, the service rebuilds its bucket cli
 listener in place — a rotated S3 credential needs no restart. `telemetry.*` is the exception:
 the log subscriber and the Sentry client are installed once and still need one.
 
+Every generation logs which layer supplied each key, so an unexpected value can be traced to the
+file or variable it came from without attaching a debugger.
+
 See [config.example.toml](config.example.toml) for a complete file.
 
-| Key                   | Required | Environment variable                    | Description                                    | Example                                  |
-|-----------------------|----------|-----------------------------------------|------------------------------------------------|------------------------------------------|
-| `s3.access_key`       | X        | `S3_PERMA_LINK_S3__ACCESS_KEY`          | S3 access key                                  | `e25a2fd93e1049a4bb48d00907d6f4bf.access` |
-| `s3.secret_key`       | X        | `S3_PERMA_LINK_S3__SECRET_KEY`          | S3 secret key                                  | `a5990007b7a54f83b52594a86c4d520e`       |
-| `s3.host`             | X        | `S3_PERMA_LINK_S3__HOST`                | S3 endpoint                                    | `s3.amazon.com`                          |
-| `s3.region`           | X        | `S3_PERMA_LINK_S3__REGION`              | S3 region                                      | `eu-central-1`                           |
-| `bucket.entries`      | X        | see below                               | Request path to bucket and object key          | see below                                |
-| `server.host`         |          | `S3_PERMA_LINK_SERVER__HOST`            | Listen address [default: `0.0.0.0`]            | `0.0.0.0`                                |
-| `server.port`         |          | `S3_PERMA_LINK_SERVER__PORT`            | Listen port [default: `8080`]                  | `9090`                                   |
-| `telemetry.log_level` |          | `S3_PERMA_LINK_TELEMETRY__LOG_LEVEL`    | `trace`/`debug`/`info`/`warn`/`error` [default: `info`] | `info`                          |
-| `telemetry.sentry_dsn`|          | `S3_PERMA_LINK_TELEMETRY__SENTRY_DSN`   | Sentry DSN; absent disables Sentry             |                                          |
+#### The variables read before the configuration exists
 
-`bucket.entries` is a table keyed by request path:
+| Variable | Role | Default | Purpose |
+|---|---|---|---|
+| `S3_PERMA_LINK_CONFIG` | config | `config.toml` | Names the TOML layer: a file, or a directory whose `*.toml` files are all merged in name order. |
+| `S3_PERMA_LINK_SECRETS_DIR` | secrets dir | — | Names a directory of key-named files — a mounted Kubernetes `Secret` volume. Each file supplies the key its name spells. |
+
+#### The keys
+
+Every key below is spelled the same way in all four layers: `__` separates nesting levels and
+case is folded. `s3.secret_key` is `S3_PERMA_LINK_S3__SECRET_KEY` as an environment
+variable, `S3_PERMA_LINK_S3__SECRET_KEY_FILE` as file indirection, and
+`s3__secret_key` as a file name inside `$S3_PERMA_LINK_SECRETS_DIR`.
+
+| TOML | Type | Environment | Default | Flags | Purpose |
+|---|---|---|---|---|---|
+| `server.host` | `String` | `S3_PERMA_LINK_SERVER__HOST` | `0.0.0.0` | — | Address to listen on. `0.0.0.0` in a container, which is the deployment this ships as. |
+| `server.port` | `u16` | `S3_PERMA_LINK_SERVER__PORT` | `8080` | — | Port to listen on. |
+| `s3.access_key` | `SecretString` | `S3_PERMA_LINK_S3__ACCESS_KEY` | — | required, secret | S3 access key. Mount it rather than setting it in a file that is committed. |
+| `s3.secret_key` | `SecretString` | `S3_PERMA_LINK_S3__SECRET_KEY` | — | required, secret | S3 secret key. Mount it rather than setting it in a file that is committed. |
+| `s3.host` | `String` | `S3_PERMA_LINK_S3__HOST` | — | required | The endpoint, e.g. `s3.eu-central-1.amazonaws.com`. |
+| `s3.region` | `String` | `S3_PERMA_LINK_S3__REGION` | — | required | The region the endpoint serves, e.g. `eu-central-1`. |
+| `bucket.entries` | `HashMap<String, BucketEntry>` | `S3_PERMA_LINK_BUCKET__ENTRIES` | — | required | One `[bucket.entries.<request path>]` block per permanent link, each carrying a `bucket` and an `object`. |
+| `telemetry.log_level` | `String` | `S3_PERMA_LINK_TELEMETRY__LOG_LEVEL` | `info` | — | How much the service says: `trace`, `debug`, `info`, `warn` or `error`. |
+| `telemetry.sentry_dsn` | `SecretString` | `S3_PERMA_LINK_TELEMETRY__SENTRY_DSN` | unset | secret | Sentry DSN. Absent disables Sentry entirely. |
+
+`bucket.entries` is one row above rather than one per link, because the key paths under it are
+route names no type knows ahead of time. Each is a table keyed by request path:
 
 ```toml
 [bucket.entries."docs/handbook"]
@@ -80,7 +116,20 @@ S3_PERMA_LINK_BUCKET__ENTRIES__CHANGELOG__BUCKET=media
 S3_PERMA_LINK_BUCKET__ENTRIES__CHANGELOG__OBJECT=releases/CHANGELOG.md
 ```
 
+## Contributing
+
+`README.md` is generated. Edit [.github/templates/README.md.hbs](.github/templates/README.md.hbs)
+instead — CI renders it on every pull request and commits the result back to the branch, and a
+push to `master` whose `README.md` does not match its template fails.
+
+The configuration tables in it are generated from `Config` in
+[src/config.rs](src/config.rs), so a key is documented by documenting the field:
+
+```bash
+cargo run --example config-schema -- --format markdown
+```
+
 ## License
 
-See [LICENSE](https://github.com/TimSchoenle/s3-bucket-perma-link/blob/main/LICENSE.md) for
+See [LICENSE](https://github.com/TimSchoenle/s3-bucket-perma-link/blob/master/LICENSE) for
 more information.

--- a/examples/config-schema.rs
+++ b/examples/config-schema.rs
@@ -1,0 +1,96 @@
+//! Dump the configuration surface of `Config`, for documentation and for editor tooling.
+//!
+//! The loader hands a merged figment to `serde` and takes back a `Config`; it never learns the
+//! shape of one. `terrace-config`'s `schema` feature inverts that, so every artefact describing
+//! the configuration is generated from the type in `src/config.rs` rather than maintained beside
+//! it and left to drift:
+//!
+//! ```text
+//! cargo run --example config-schema -- --format markdown    # the README tables
+//! cargo run --example config-schema -- --format json        # the machine-readable contract
+//! cargo run --example config-schema -- --format json-schema # for an editor to validate against
+//! ```
+//!
+//! `--format markdown` is the one the README is built from — `examples/readme-variables.rs`
+//! embeds the same tables into the template. Run it here to read them on their own.
+//!
+//! Nothing below reads the environment, so the output is the same on a developer's machine as on
+//! a runner where none of the variables it describes exist.
+
+use std::process::ExitCode;
+
+use s3_bucket_perma_link::config;
+use terrace_config::schema::JsonSchema;
+
+/// The `$id` the generated JSON Schema carries.
+const SCHEMA_ID: &str = "https://github.com/TimSchoenle/s3-bucket-perma-link/config.schema.json";
+
+fn main() -> ExitCode {
+    let format = match Format::from_args() {
+        Ok(format) => format,
+        Err(message) => {
+            eprintln!("{message}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    match render(format) {
+        Ok(rendered) => {
+            print!("{rendered}");
+            ExitCode::SUCCESS
+        }
+        Err(error) => {
+            eprintln!("{error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn render(format: Format) -> Result<String, config::ConfigError> {
+    let schema = config::schema()?;
+
+    match format {
+        Format::Markdown => Ok(schema.to_markdown()),
+        Format::Json => schema.to_json(),
+        Format::JsonSchema => schema.to_json_schema_with(
+            &JsonSchema::new()
+                .title("s3-bucket-perma-link configuration")
+                .id(SCHEMA_ID),
+        ),
+    }
+}
+
+/// Which rendering to emit.
+enum Format {
+    /// GitHub-flavoured tables, for a pipeline whose next step is a README.
+    Markdown,
+    /// The versioned contract, for a pipeline that renders its own tables.
+    Json,
+    /// A JSON Schema, for an editor to validate a `config.toml` against.
+    JsonSchema,
+}
+
+impl Format {
+    /// JSON unless asked otherwise: it is the rendering that loses nothing.
+    fn from_args() -> Result<Self, String> {
+        let mut format = Self::Json;
+        let mut args = std::env::args().skip(1);
+        while let Some(flag) = args.next() {
+            match flag.as_str() {
+                "--format" => {
+                    format = match args.next().as_deref() {
+                        Some("markdown" | "md") => Self::Markdown,
+                        Some("json") => Self::Json,
+                        Some("json-schema" | "jsonschema") => Self::JsonSchema,
+                        Some(other) => return Err(format!("unknown format `{other}`; {USAGE}")),
+                        None => return Err(format!("--format takes a value; {USAGE}")),
+                    };
+                }
+                other => return Err(format!("unknown argument `{other}`; {USAGE}")),
+            }
+        }
+        Ok(format)
+    }
+}
+
+const USAGE: &str = "usage: config-schema [--format markdown|json|json-schema]";

--- a/examples/readme-variables.rs
+++ b/examples/readme-variables.rs
@@ -1,0 +1,85 @@
+//! Emit the variable payload for `.github/templates/README.md.hbs` as strict JSON on stdout.
+//!
+//! `README.md` is rendered from that template by `.github/workflows/docs.yml`, so every value in
+//! it that is derived from something else in the repository is derived *here* rather than typed
+//! into the README and left to rot. Two kinds of value qualify:
+//!
+//! - **The configuration reference.** Both tables come off `Config` through `config::schema`,
+//!   which means a key added to that type without a `///` comment shows an empty Purpose cell in
+//!   the pull request that adds it, and a key removed from it leaves the README on the same
+//!   commit.
+//! - **The spellings the surrounding prose quotes.** The prefix, `S3_PERMA_LINK_CONFIG` and
+//!   `S3_PERMA_LINK_SECRETS_DIR` come from the loader itself, so prose naming a variable the
+//!   service does not read is not expressible.
+//!
+//! The repository coordinates below it are the third kind: a constant with exactly one
+//! definition, rather than the same string typed into nine badge URLs.
+//!
+//! Run it yourself to see what CI will render with:
+//!
+//! ```text
+//! cargo run --example readme-variables
+//! ```
+//!
+//! Output is one line, because the workflow step carries it through `$GITHUB_OUTPUT`, where a
+//! value is one line by definition.
+
+use std::process::ExitCode;
+
+use s3_bucket_perma_link::config;
+use serde_json::json;
+use terrace_config::schema::Column;
+
+/// `owner/repo`, as every badge and link in the README spells it.
+const REPOSITORY: &str = "TimSchoenle/s3-bucket-perma-link";
+
+/// The branch the README's permalinks point at.
+const BRANCH: &str = "master";
+
+/// The workflow whose status the build badge shows. A file name, not a display name — the badge
+/// URL takes the path, and getting it wrong renders a badge that reads "no status".
+const BUILD_WORKFLOW: &str = "build.yaml";
+
+/// The published image. Not derivable from the manifest: nothing in `Cargo.toml` names it.
+const DOCKER_IMAGE: &str = "timmi6790/s3-bucket-perma-link";
+
+fn main() -> ExitCode {
+    match variables() {
+        Ok(json) => {
+            println!("{json}");
+            ExitCode::SUCCESS
+        }
+        Err(error) => {
+            eprintln!("readme-variables: {error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+/// The payload, as one line of strict JSON.
+///
+/// Fails if the schema cannot be built or the payload cannot be serialised. Neither is reachable
+/// while `cargo test` passes, and both are worth failing the documentation job over rather than
+/// rendering a README around a hole.
+fn variables() -> Result<String, Box<dyn std::error::Error>> {
+    let terrace = config::terrace();
+    let schema = config::schema()?;
+
+    let payload = json!({
+        "repo": REPOSITORY,
+        "branch": BRANCH,
+        "build_workflow": BUILD_WORKFLOW,
+        "docker_image": DOCKER_IMAGE,
+        "prefix": terrace.dialect().prefix(),
+        "config_var": terrace.config_var_name(),
+        "secrets_dir_var": terrace.secrets_dir_var_name(),
+        "indirection_suffix": terrace.dialect().indirection_suffix(),
+        // The two tables separately rather than through `to_markdown`: the README puts a
+        // paragraph between them, and welding them together here would mean cutting them apart
+        // in the template.
+        "loader_table": schema.to_markdown_loader(),
+        "keys_table": schema.to_markdown_keys(Column::DEFAULT),
+    });
+
+    Ok(serde_json::to_string(&payload)?)
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,68 +13,111 @@ mod loader;
 use s3::creds::Credentials;
 use s3::{Bucket, Region};
 use secrecy::{ExposeSecret, SecretString};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::str::FromStr;
+use terrace_config::schema::{Describe, Schema};
 use tracing::Level;
 
 use crate::error::Error;
 
-pub use loader::{ConfigError, Loaded, Sources, load, load_watched, terrace};
+pub use loader::{ConfigError, Loaded, Sources, explain, load, load_watched, terrace};
 
 const DEFAULT_SERVER_HOST: &str = "0.0.0.0";
 const DEFAULT_SERVER_PORT: u16 = 8080;
 const DEFAULT_LOG_LEVEL: &str = "info";
 
 /// Everything the service reads at boot.
-#[derive(Debug, Deserialize, Getters)]
+///
+/// [`Describe`] is what the configuration reference in `README.md` is generated from: the key
+/// paths, the environment spellings, the types and the `///` comments below are read off this
+/// tree by `examples/config-schema.rs` rather than restated in prose that can drift from it.
+#[derive(Debug, Deserialize, Serialize, Getters, Describe)]
 #[getset(get = "pub")]
 pub struct Config {
+    #[config(nested)]
     #[serde(default)]
     server: ServerConfig,
+    #[config(nested)]
     s3: S3Config,
+    #[config(nested)]
     bucket: BucketConfig,
+    #[config(nested)]
     #[serde(default)]
     telemetry: TelemetryConfig,
 }
 
+/// What the schema generator reads the `Default` column out of.
+///
+/// It is not a configuration a service could run on: [`S3Config`]'s fields are required, and a
+/// required key reports no default at all, so nothing here reaches the generated table. Only the
+/// blocks that really do have defaults — [`ServerConfig`] and [`TelemetryConfig`] — contribute.
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            server: ServerConfig::default(),
+            s3: S3Config::default(),
+            bucket: BucketConfig::default(),
+            telemetry: TelemetryConfig::default(),
+        }
+    }
+}
+
 /// Where the object store lives and how to authenticate against it.
-#[derive(Debug, Deserialize, Getters)]
+#[derive(Debug, Deserialize, Serialize, Default, Getters, Describe)]
 #[getset(get = "pub")]
 pub struct S3Config {
+    /// S3 access key. Mount it rather than setting it in a file that is committed.
+    ///
     /// A [`SecretString`]: this struct is nested inside a [`Config`] that the reload supervisor
-    /// logs, and a credential must not be one `{:?}` away from the log stream.
+    /// logs, and a credential must not be one `{:?}` away from the log stream. `SecretString`
+    /// refuses to implement [`Serialize`] for the same reason, which is why the field is skipped
+    /// on the way out — `#[config(secret)]` renders `<redacted>` in its place anyway.
+    #[config(secret)]
+    #[serde(skip_serializing)]
     access_key: SecretString,
+    /// S3 secret key. Mount it rather than setting it in a file that is committed.
+    #[config(secret)]
+    #[serde(skip_serializing)]
     secret_key: SecretString,
     /// The endpoint, e.g. `s3.eu-central-1.amazonaws.com`.
     host: String,
+    /// The region the endpoint serves, e.g. `eu-central-1`.
     region: String,
 }
 
 /// The listener the service binds.
-#[derive(Debug, Deserialize, Getters)]
+#[derive(Debug, Deserialize, Serialize, Getters, Describe)]
 #[getset(get = "pub")]
 pub struct ServerConfig {
+    /// Address to listen on. `0.0.0.0` in a container, which is the deployment this ships as.
     #[serde(default = "ServerConfig::default_host")]
     host: String,
+    /// Port to listen on.
     #[serde(default = "ServerConfig::default_port")]
     port: u16,
 }
 
 /// The routes the service serves, and the object each one resolves to.
-#[derive(Debug, Deserialize, Getters)]
+#[derive(Debug, Deserialize, Serialize, Default, Getters, Describe)]
 #[getset(get = "pub")]
 pub struct BucketConfig {
-    /// Request path to object. A table rather than the delimiter-separated string this used to
-    /// be: the string existed only because an environment variable cannot carry a map, and the
-    /// TOML layer can.
+    /// One `[bucket.entries.<request path>]` block per permanent link, each carrying a `bucket`
+    /// and an `object`.
+    ///
+    /// A leaf rather than `#[config(nested)]`, because the key paths under it are the operator's
+    /// route names and no type knows them ahead of time — see [`BucketEntry`] for the two fields
+    /// each block takes. A table rather than the delimiter-separated string this used to be: the
+    /// string existed only because an environment variable cannot carry a map, and the TOML layer
+    /// can.
     entries: HashMap<String, BucketEntry>,
 }
 
 /// One route's object.
-#[derive(Debug, Clone, Deserialize, Getters)]
+#[derive(Debug, Clone, Deserialize, Serialize, Getters)]
 #[getset(get = "pub")]
 pub struct BucketEntry {
+    /// The bucket [`Self::object`] lives in.
     bucket: String,
     /// The object key inside [`Self::bucket`].
     ///
@@ -88,16 +131,42 @@ pub struct BucketEntry {
 ///
 /// Both are installed once, before the reload supervisor is reached, and cannot be reinstalled
 /// on a running process — so this is the one block a configuration reload does not apply.
-#[derive(Debug, Deserialize, Getters)]
+#[derive(Debug, Deserialize, Serialize, Getters, Describe)]
 #[getset(get = "pub")]
 pub struct TelemetryConfig {
-    /// `trace`, `debug`, `info`, `warn` or `error`. Parsed by [`Self::level`].
+    /// How much the service says: `trace`, `debug`, `info`, `warn` or `error`.
+    ///
+    /// Parsed by [`Self::level`].
     #[serde(default = "TelemetryConfig::default_log_level")]
     log_level: String,
-    /// Absent disables Sentry entirely. A [`SecretString`]: a DSN is a write credential for
-    /// the project it names.
-    #[serde(default)]
+    /// Sentry DSN. Absent disables Sentry entirely.
+    ///
+    /// A [`SecretString`]: a DSN is a write credential for the project it names — and, like the
+    /// S3 credentials, one serde must not be able to write back out.
+    #[config(secret)]
+    #[serde(default, skip_serializing)]
     sentry_dsn: Option<SecretString>,
+}
+
+/// The configuration surface, described rather than deserialised.
+///
+/// The reference tables in `README.md` are rendered from this: the key paths, the environment
+/// spellings, the types, the defaults and the `///` comments all come off [`Config`], so the
+/// documentation cannot say something the type does not. `examples/config-schema.rs` and
+/// `examples/readme-variables.rs` are the two callers; both go through here so that neither can
+/// describe a different loader than the service boots with.
+///
+/// Reads nothing from the environment — the `Default` column is filled from [`Config::default`],
+/// so a documentation job produces the same answer on a runner where none of these variables
+/// exist. Required keys report no default at all, which is why the empty S3 credentials
+/// [`Config::default`] carries never reach the table.
+///
+/// # Errors
+/// Returns [`ConfigError`] if [`Config`] does not serialise.
+pub fn schema() -> Result<Schema, ConfigError> {
+    terrace()
+        .schema::<Config>()
+        .with_defaults_from(&Config::default())
 }
 
 impl ServerConfig {

--- a/src/config/loader.rs
+++ b/src/config/loader.rs
@@ -7,6 +7,7 @@
 
 use serde::de::DeserializeOwned;
 use terrace_config::Terrace;
+use terrace_config::explain::Explanation;
 
 pub use terrace_config::{Error as ConfigError, Loaded, Sources};
 
@@ -27,6 +28,10 @@ const PREFIX: &str = "S3_PERMA_LINK_";
 /// `terrace-config` reserves itself: every value this service reads, the Sentry DSN and the log
 /// level included, is read out of the layers rather than out of the environment directly, so
 /// there is no key a mounted file could supply to nobody.
+///
+/// One function, used by all four callers — the boot in `main`, the reload the supervisor
+/// drives, the schema the README is generated from, and the tests — so none of them can be
+/// reading a dialect the others do not.
 #[must_use]
 pub fn terrace() -> Terrace {
     Terrace::new(PREFIX)
@@ -50,40 +55,58 @@ pub fn load_watched<T: DeserializeOwned>() -> Result<Loaded<T>, ConfigError> {
     terrace().load_watched()
 }
 
+/// Which layer supplied each key, as it stands right now.
+///
+/// Holds no configuration value — not redacted on the way out, never recorded — so the report is
+/// safe to log in full. That is what makes it worth logging at all: "the mounted secret is not
+/// being picked up" is answered by a report naming the mount and the stale environment variable
+/// sitting on top of it, without a debugger and without a redeploy.
+///
+/// It re-reads at the moment it is called, so calling it from inside a rebuilt runtime describes
+/// the layers that rebuild saw rather than the ones the process booted on.
+///
+/// # Errors
+/// Returns [`ConfigError`] if a file-backed layer cannot be read. A configuration [`load`]
+/// *refuses* still explains: a key supplied twice is reported as one key with two sources.
+pub fn explain() -> Result<Explanation, ConfigError> {
+    terrace().explain()
+}
+
 #[cfg(test)]
 mod tests {
-    use super::load;
+    use super::terrace;
     use crate::config::Config;
     use secrecy::ExposeSecret;
+    use terrace_config::explain::{Layer, Origin};
+    use terrace_config::testing::{Harness, Jail};
 
-    /// Set the two S3 credentials every load needs, so a test can say only what it is about.
-    fn set_credentials(jail: &mut figment::Jail) {
-        jail.set_env("S3_PERMA_LINK_S3__ACCESS_KEY", "access");
-        jail.set_env("S3_PERMA_LINK_S3__SECRET_KEY", "secret");
-        jail.set_env("S3_PERMA_LINK_S3__HOST", "s3.example.com");
-        jail.set_env("S3_PERMA_LINK_S3__REGION", "eu-central-1");
+    /// The sandbox every test below runs in: an empty environment, a temporary working directory,
+    /// and *this* crate's loader — so no test can pass against a variable name the service does
+    /// not read.
+    fn harness() -> Harness {
+        Harness::over(terrace())
+    }
+
+    /// Set the four values every load needs, so a test can say only what it is about.
+    fn set_credentials(jail: &mut Jail<'_>) {
+        jail.env_key("s3.access_key", "access");
+        jail.env_key("s3.secret_key", "secret");
+        jail.env_key("s3.host", "s3.example.com");
+        jail.env_key("s3.region", "eu-central-1");
     }
 
     /// The dialect, end to end: the prefix, the `__` nesting, and the defaults that fill in
     /// around what the environment supplied. `terrace-config` owns the layering and tests it;
     /// what this pins is that the service wires it to the names an operator actually sets.
     #[test]
-    #[expect(
-        clippy::result_large_err,
-        reason = "figment::Jail::expect_with fixes the closure's error type"
-    )]
     fn env_overrides_and_defaults_apply() {
-        figment::Jail::expect_with(|jail| {
-            jail.clear_env();
+        harness().run(|jail| {
             set_credentials(jail);
-            jail.set_env("S3_PERMA_LINK_BUCKET__ENTRIES__docs__BUCKET", "media");
-            jail.set_env(
-                "S3_PERMA_LINK_BUCKET__ENTRIES__docs__OBJECT",
-                "handbook.pdf",
-            );
-            jail.set_env("S3_PERMA_LINK_SERVER__PORT", "9090");
+            jail.env_key("bucket.entries.docs.bucket", "media");
+            jail.env_key("bucket.entries.docs.object", "handbook.pdf");
+            jail.env_key("server.port", 9090);
 
-            let config: Config = load().map_err(|e| e.to_string()).unwrap();
+            let config: Config = jail.load()?;
 
             // `SecretString` has no `PartialEq`; comparing requires `expose_secret()`.
             assert_eq!(config.s3().access_key().expose_secret(), "access");
@@ -105,18 +128,12 @@ mod tests {
     /// layers: the entries used to be squeezed into one `key:bucket,file; ...` string because
     /// an environment variable cannot carry a map.
     #[test]
-    #[expect(
-        clippy::result_large_err,
-        reason = "figment::Jail::expect_with fixes the closure's error type"
-    )]
     fn the_toml_layer_carries_the_bucket_table() {
-        figment::Jail::expect_with(|jail| {
-            jail.clear_env();
+        harness().run(|jail| {
             set_credentials(jail);
-            // No `S3_PERMA_LINK_CONFIG`: this also pins the `config.toml` fallback, which is
-            // what a container with a `ConfigMap` mounted over its working directory uses.
-            jail.create_file(
-                "config.toml",
+            // No path given: this also pins the `config.toml` fallback, which is what a container
+            // with a `ConfigMap` mounted over its working directory uses.
+            jail.config(
                 r#"
 [bucket.entries.docs]
 bucket = "media"
@@ -128,7 +145,7 @@ object = "CHANGELOG.md"
 "#,
             )?;
 
-            let config: Config = load().map_err(|e| e.to_string()).unwrap();
+            let config: Config = jail.load()?;
 
             assert_eq!(config.bucket().entries().len(), 2);
             // A key an environment variable could not have spelled: the environment layer
@@ -149,16 +166,15 @@ object = "CHANGELOG.md"
     /// A mounted secret outranks the TOML layer, so a `ConfigMap` carrying a placeholder key
     /// cannot win over the `Secret` that carries the real one — through the variable names
     /// *this* crate configures, which is the half a dependency cannot pin.
+    ///
+    /// The mount has the shape a projected volume has — a generation directory and a `..data`
+    /// entry beside the keys — rather than being a tidy directory of plain files. Which of the
+    /// two a provider walks correctly is the difference between reading a `Secret` and booting on
+    /// compiled defaults with a perfectly good one mounted beside you.
     #[test]
-    #[expect(
-        clippy::result_large_err,
-        reason = "figment::Jail::expect_with fixes the closure's error type"
-    )]
     fn a_secrets_directory_outranks_the_toml_layer() {
-        figment::Jail::expect_with(|jail| {
-            jail.clear_env();
-            jail.create_file(
-                "config.toml",
+        harness().run(|jail| {
+            jail.config(
                 r#"
 [s3]
 access_key = "placeholder"
@@ -171,18 +187,27 @@ bucket = "media"
 object = "handbook.pdf"
 "#,
             )?;
-            jail.create_dir("secrets")?;
-            jail.create_file("secrets/s3__secret_key", "rotated\n")?;
-            jail.set_env(
-                "S3_PERMA_LINK_SECRETS_DIR",
-                jail.directory().join("secrets").display(),
-            );
+            jail.secrets_volume()
+                .file("s3__secret_key", "rotated\n")
+                .projected()
+                .create()?;
 
-            let config: Config = load().map_err(|e| e.to_string()).unwrap();
+            let config: Config = jail.load()?;
 
             assert_eq!(config.s3().secret_key().expose_secret(), "rotated");
             // The key the mount said nothing about still comes from the TOML layer.
             assert_eq!(config.s3().access_key().expose_secret(), "placeholder");
+            // The value alone would also be produced by a `config.toml` that happened to say
+            // `rotated`. Which layer won is what this test is about.
+            let explanation = jail.explain()?;
+            let origin = explanation
+                .origin("s3.secret_key")
+                .expect("the mounted key is reported");
+            assert!(
+                matches!(origin.effective(), Layer::SecretsFile(_)),
+                "the secret must come from the mount, not from {}",
+                origin.effective()
+            );
             Ok(())
         });
     }
@@ -190,31 +215,21 @@ object = "handbook.pdf"
     /// A single value can also be pointed at a file by name, which is the `_FILE` convention a
     /// Docker Compose stack spells rather than mounting a whole secrets directory.
     #[test]
-    #[expect(
-        clippy::result_large_err,
-        reason = "figment::Jail::expect_with fixes the closure's error type"
-    )]
     fn a_file_indirection_variable_supplies_one_key() {
-        figment::Jail::expect_with(|jail| {
-            jail.clear_env();
+        harness().run(|jail| {
             // Everything but the secret, which the indirection variable supplies instead.
-            jail.set_env("S3_PERMA_LINK_S3__ACCESS_KEY", "access");
-            jail.set_env("S3_PERMA_LINK_S3__HOST", "s3.example.com");
-            jail.set_env("S3_PERMA_LINK_S3__REGION", "eu-central-1");
-            jail.set_env("S3_PERMA_LINK_BUCKET__ENTRIES__docs__BUCKET", "media");
-            jail.set_env(
-                "S3_PERMA_LINK_BUCKET__ENTRIES__docs__OBJECT",
-                "handbook.pdf",
-            );
+            jail.env_key("s3.access_key", "access");
+            jail.env_key("s3.host", "s3.example.com");
+            jail.env_key("s3.region", "eu-central-1");
+            jail.env_key("bucket.entries.docs.bucket", "media");
+            jail.env_key("bucket.entries.docs.object", "handbook.pdf");
 
-            jail.create_file("secret_key", "from-a-file\n")?;
-            // The value names the *path*; the key it fills is the one before `_FILE`.
-            jail.set_env(
-                "S3_PERMA_LINK_S3__SECRET_KEY_FILE",
-                jail.directory().join("secret_key").display(),
-            );
+            // Writes the file *and* sets the variable naming it, both derived from the key: a
+            // test spelling `S3_PERMA_LINK_S3__SECRET_KEY_FILE` out by hand would keep passing
+            // after the suffix was renamed, while testing a variable nothing reads.
+            jail.indirection("s3.secret_key", "from-a-file\n")?;
 
-            let config: Config = load().map_err(|e| e.to_string()).unwrap();
+            let config: Config = jail.load()?;
 
             // Trailing newline trimmed: an editor or a `kubectl create secret --from-file`
             // adds one, and it is not part of the credential.
@@ -228,26 +243,41 @@ object = "handbook.pdf"
     /// rotated, so silently preferring either is how a service keeps serving on a credential
     /// its operator believes they replaced.
     #[test]
-    #[expect(
-        clippy::result_large_err,
-        reason = "figment::Jail::expect_with fixes the closure's error type"
-    )]
     fn a_key_supplied_twice_is_refused() {
-        figment::Jail::expect_with(|jail| {
-            jail.clear_env();
+        harness().run(|jail| {
             set_credentials(jail);
-            jail.create_dir("secrets")?;
-            jail.create_file("secrets/s3__secret_key", "rotated")?;
-            jail.set_env(
-                "S3_PERMA_LINK_SECRETS_DIR",
-                jail.directory().join("secrets").display(),
-            );
+            jail.secret_key("s3.secret_key", "rotated")?;
 
-            let error = load::<Config>().expect_err("a shadowed key must fail the boot");
+            let error = jail
+                .load::<Config>()
+                .expect_err("a shadowed key must fail the boot");
             assert!(
                 error.to_string().to_lowercase().contains("secret_key"),
                 "the error must name the key: {error}"
             );
+            Ok(())
+        });
+    }
+
+    /// The report `main` logs once per generation, on the case it exists for: a key the boot
+    /// refuses. A report that named the mount but not the variable shadowing it would leave the
+    /// operator exactly where they started.
+    #[test]
+    fn the_explanation_names_a_contested_key() {
+        harness().run(|jail| {
+            set_credentials(jail);
+            jail.secret_key("s3.secret_key", "rotated")?;
+
+            let explanation = jail.explain()?;
+            let contested: Vec<&str> = explanation.contested().map(Origin::key).collect();
+            assert_eq!(contested, ["s3.secret_key"]);
+
+            // Assembled under `LastWins` whatever policy is set, so the configuration the test
+            // above watches `load` refuse is still explainable — which is the moment it is
+            // wanted. Both sources are named, not just the winner.
+            let report = explanation.to_string();
+            assert!(report.contains("S3_PERMA_LINK_S3__SECRET_KEY"), "{report}");
+            assert!(report.contains("s3__secret_key"), "{report}");
             Ok(())
         });
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,11 +50,29 @@ async fn main() -> Result<()> {
 /// Returns when `shutdown` is cancelled — by the OS signal, or by the supervisor because the
 /// configuration changed and this runtime is being replaced.
 async fn serve(config: Arc<Config>, shutdown: CancellationToken) -> Result<()> {
+    log_config_sources();
+
     let buckets = config.s3().create_buckets(config.bucket().entries())?;
     let download_data = DownloadData::new(buckets, config.bucket().entries().clone());
 
     let server = Server::new(config.server().host().to_string(), *config.server().port());
     server.run_until_stopped(download_data, shutdown).await
+}
+
+/// Log which layer supplied each configuration key.
+///
+/// Here rather than at boot because this runs once per generation: after a reload the report
+/// describes the layers *that* load saw, which is the one moment the question "where did this
+/// value come from" is being asked about something that just changed.
+///
+/// The report carries no configuration value — the keys and their sources, never the contents —
+/// so there is nothing in it to redact. A failure to assemble it is not a failure to serve: the
+/// configuration it describes has already loaded, so it is logged and stepped over.
+fn log_config_sources() {
+    match config::explain() {
+        Ok(explanation) => info!("Configuration sources:\n{explanation}"),
+        Err(error) => warn!("Could not explain the configuration sources: {error}"),
+    }
 }
 
 fn setup_tracing(telemetry: &TelemetryConfig) -> Result<()> {


### PR DESCRIPTION
## What

Takes `terrace-config` from `v0.2.0` to `v0.5.0` and uses the three features that release adds, then makes `README.md` a generated file so the configuration reference cannot drift from `Config`.

## `explain`

`serve` logs which layer supplied each configuration key. It sits inside the rebuilt runtime rather than at boot, so a reload reports the layers *that* load saw — the moment the question is actually being asked:

```
INFO s3_bucket_perma_link: Configuration sources:
terrace-config: prefix `S3_PERMA_LINK_`, 7 keys
layers, lowest precedence first:
  TOML          S3_PERMA_LINK_CONFIG=/etc/s3-perma-link/config.toml
  environment   S3_PERMA_LINK_* (none)
  secrets dir   S3_PERMA_LINK_SECRETS_DIR=/run/secrets (1 key)
  indirection   S3_PERMA_LINK_*_FILE (none)
keys:
  s3.secret_key  <- secrets file /run/secrets/s3__secret_key
  ...
```

The report holds no configuration value — never recorded, so there is nothing in it to redact.

## `schema`, and the generated README

`Config` derives `Describe`, and two examples read it:

- `cargo run --example config-schema -- --format markdown|json|json-schema`
- `cargo run --example readme-variables` — the strict-JSON payload for the README template

`README.md` is rendered from `.github/templates/README.md.hbs` by the new `.github/workflows/docs.yml`, using `TimSchoenle/actions/actions/common/render-template-and-commit@actions-common-render-template-and-commit-v1.1.3` (the latest tag). On a pull request from this repository it renders and commits the result back to the branch; on pushes to `master` and on fork pull requests it runs `render-template@…v1.1.1` with `check: true`, which writes nothing and fails on a stale README. Between the two conditions every event is handled by exactly one job.

Injected into the template:

| Variable | Source |
|---|---|
| `loader_table`, `keys_table` | `Config`, through `config::schema()` |
| `prefix`, `config_var`, `secrets_dir_var`, `indirection_suffix` | the loader's own dialect in `src/config/loader.rs` |
| `repo`, `branch`, `build_workflow`, `docker_image` | one constant each, instead of nine badge URLs |

A key added to `Config` without a `///` comment now shows an empty Purpose cell in the pull request that adds it, and a key removed from it leaves the README on the same commit.

This picked up three things the hand-maintained README had drifted on: the build badge pointed at `build.yml` (the file is `build.yaml`), and the licence link pointed at `LICENSE.md` on a `main` branch that does not exist here.

## `testing`

The loader tests run in `testing::Harness` rather than `figment::Jail`, so `figment` leaves `[dev-dependencies]`. Every name a test arranges is now derived from the loader under test — `jail.indirection("s3.secret_key", …)` rather than a hand-spelled `S3_PERMA_LINK_S3__SECRET_KEY_FILE` — so a test cannot keep passing against a variable the service has stopped reading. The secrets-directory test uses the projected-volume layout a kubelet actually writes, and asserts the *layer* the value came from rather than only its value.

One new test covers the report `main` logs, on the case it exists for: a key supplied by two layers at once.

## Also

The auto-format job in `build.yaml` joins the `branch-writes-*` concurrency group. It and the README render both make verified commits to the pull request branch, and that API call rejects a commit whose parent has moved.

## Verification

- `cargo fmt --all --check`, `cargo clippy --all-targets`, `cargo test` — clean, 7 tests passing
- Rendered `README.md` locally from the template and confirmed a second render is byte-identical, which is what the `check` job asserts
- Booted the binary against a `config.toml` plus a mounted `s3__secret_key` and confirmed the provenance log attributes the secret to the mount
