### PR TITLE
fix(ci): publish the configuration contract on Docker Hub

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -333,9 +333,15 @@ jobs:
       # Attached verbatim: the bytes the generator wrote inside the build, checked against the
       # copy inside the image, with nothing added afterwards. The chart repository reads both
       # carriers and refuses the image if they differ.
+      #
+      # The reference is spelled out with its registry. `oras` does not apply Docker's implicit
+      # `docker.io` default: it reads the first segment of a bare `user/repo` as a registry
+      # hostname and tries to resolve it in DNS. Everything else in this job — buildx, cosign —
+      # defaults the registry itself, which is why these two steps are the only place it is
+      # written.
       - name: Attach the configuration contract to the image digest
         env:
-          IMAGE: ${{ env.DOCKER_REPO }}
+          IMAGE: docker.io/${{ env.DOCKER_REPO }}
           DIGEST: ${{ steps.manifest.outputs.digest }}
           CONTRACT: ${{ steps.contract.outputs.path }}
           ARTIFACT_TYPE: ${{ env.CONTRACT_ARTIFACT_TYPE }}
@@ -351,7 +357,7 @@ jobs:
       # already signed by the step above; this signs the attachment.
       - name: Sign the attached contract with GitHub OIDC Token
         env:
-          IMAGE: ${{ env.DOCKER_REPO }}
+          IMAGE: docker.io/${{ env.DOCKER_REPO }}
           DIGEST: ${{ steps.manifest.outputs.digest }}
           ARTIFACT_TYPE: ${{ env.CONTRACT_ARTIFACT_TYPE }}
         run: |


### PR DESCRIPTION
Two defects on the contract-publishing path, one behind the other.

## 1. The `oras` reference was not registry-qualified

[Release run 32230238704](https://github.com/TimSchoenle/s3-bucket-perma-link/actions/runs/32230238704/job/96005375697) failed at **Attach the configuration contract to the image digest**:

```
Error: failed to resolve sha256:350305d2...: Head "https://***/v2/s3-bucket-perma-link/manifests/sha256:350305d2...":
dial tcp: lookup *** on 127.0.0.53:53: server misbehaving
```

`IMAGE` was `DOCKER_REPO`, the bare Docker Hub form `user/repo`. Unlike buildx and cosign, `oras` applies no implicit `docker.io` default — it parses the first path segment as a registry hostname, so it tried to resolve the account name in DNS. The `***` in the log is that account name, masked because it matches `DOCKERHUB_USERNAME`.

Both `oras`-facing steps now name `docker.io`. That is the form `oras-go` maps to the `registry-1.docker.io` endpoint (`registry.Reference.Host()`) and to the `https://index.docker.io/v1/` credential entry `docker/login-action` writes (`auth.ServerAddressFromRegistry`), so the existing login still authenticates.

`DOCKER_REPO` itself is left alone — it also feeds the published tags and the chart values, and every other tool in the job resolves the short form on its own.

## 2. Behind it: the referrers index is eventually consistent

Fixing the reference gets the attach through and lands on the next failure. Docker Hub's referrers index does not list an attachment immediately: `oras attach` returns as soon as the referrer manifest is stored, but `/v2/<repo>/referrers/<digest>` keeps answering with an empty index for seconds afterwards, so the discover in the signing step reads nothing.

Confirmed, not inferred. [`mp-stats-legacy-viewer` v0.17.0](https://github.com/TimSchoenle/mp-stats-legacy-viewer/actions/runs/32225323396/job/95984282436) reached this point first, because its reference was already registry-qualified. Its attach printed referrer `sha256:2cad9caa…`; its discover 200ms later returned an empty list and failed the release; querying that digest's referrers today returns `sha256:2cad9caa…` with `artifactType: application/vnd.terrace.config-schema.v1+json`.

The discover is now polled on a 5/10/15/20/25s schedule before the step gives up.

## Verification

- Workflow YAML parses; every `run:` block in the file passes `bash -n`.
- Cause 1 confirmed against `oras-go` upstream for both reference parsing and credential lookup; cause 2 against Docker Hub's live registry API, as described above.
- End-to-end confirmation needs a release run, since these steps only execute on `release_created`.

## Notes

- The same two defects were present in `cloudflare-access-webhook-redirect`, whose release run failed identically; fixed there in TimSchoenle/cloudflare-access-webhook-redirect#418.
- v1.1.0's contract stays unattached; re-attaching it to that digest needs a manual `oras attach`, or it can wait for the next release.
