### PR TITLE
fix(ci): qualify the contract's image reference with docker.io

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -333,9 +333,15 @@ jobs:
       # Attached verbatim: the bytes the generator wrote inside the build, checked against the
       # copy inside the image, with nothing added afterwards. The chart repository reads both
       # carriers and refuses the image if they differ.
+      #
+      # The reference is spelled out with its registry. `oras` does not apply Docker's implicit
+      # `docker.io` default: it reads the first segment of a bare `user/repo` as a registry
+      # hostname and tries to resolve it in DNS. Everything else in this job — buildx, cosign —
+      # defaults the registry itself, which is why these two steps are the only place it is
+      # written.
       - name: Attach the configuration contract to the image digest
         env:
-          IMAGE: ${{ env.DOCKER_REPO }}
+          IMAGE: docker.io/${{ env.DOCKER_REPO }}
           DIGEST: ${{ steps.manifest.outputs.digest }}
           CONTRACT: ${{ steps.contract.outputs.path }}
           ARTIFACT_TYPE: ${{ env.CONTRACT_ARTIFACT_TYPE }}
@@ -351,7 +357,7 @@ jobs:
       # already signed by the step above; this signs the attachment.
       - name: Sign the attached contract with GitHub OIDC Token
         env:
-          IMAGE: ${{ env.DOCKER_REPO }}
+          IMAGE: docker.io/${{ env.DOCKER_REPO }}
           DIGEST: ${{ steps.manifest.outputs.digest }}
           ARTIFACT_TYPE: ${{ env.CONTRACT_ARTIFACT_TYPE }}
         run: |

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -362,12 +362,27 @@ jobs:
           ARTIFACT_TYPE: ${{ env.CONTRACT_ARTIFACT_TYPE }}
         run: |
           set -euo pipefail
+          # Polled rather than read once. Docker Hub's referrers index is eventually consistent:
+          # the attach above returns as soon as the referrer manifest is stored, but
+          # `/v2/.../referrers/<digest>` keeps answering with an empty index for seconds
+          # afterwards, which fails this step over a contract that is in fact attached.
+          #
           # `oras discover` has spelled its top-level key differently across releases; both are
           # accepted rather than pinning the shape to the version that happens to be installed.
-          referrers="$(oras discover --format json --artifact-type "${ARTIFACT_TYPE}" "${IMAGE}@${DIGEST}")"
-          count="$(jq '[.referrers // .manifests // []] | flatten | length' <<< "${referrers}")"
+          referrers=""
+          count=0
+          for attempt in 1 2 3 4 5 6; do
+            if [ "${attempt}" -gt 1 ]; then
+              sleep $(( (attempt - 1) * 5 ))
+            fi
+            referrers="$(oras discover --format json --artifact-type "${ARTIFACT_TYPE}" "${IMAGE}@${DIGEST}")"
+            count="$(jq '[.referrers // .manifests // []] | flatten | length' <<< "${referrers}")"
+            if [ "${count}" != "0" ]; then
+              break
+            fi
+          done
           if [ "${count}" != "1" ]; then
-            echo "::error::expected exactly one ${ARTIFACT_TYPE} referrer on ${IMAGE}@${DIGEST}, found ${count}"
+            echo "::error::expected exactly one ${ARTIFACT_TYPE} referrer on ${IMAGE}@${DIGEST} within 75s of attaching it, found ${count}"
             exit 1
           fi
           reference="$(jq -r '[.referrers // .manifests // []] | flatten | .[0].reference // empty' <<< "${referrers}")"


### PR DESCRIPTION
`oras attach` and `oras discover` were handed the bare `user/repo@digest`
form. Unlike buildx and cosign, `oras` applies no implicit Docker Hub
default: it reads the first path segment as a registry hostname, so the
release job resolved the Docker Hub account name in DNS and failed with
`failed to resolve ...: dial tcp: lookup ...: server misbehaving`,
leaving the configuration contract unattached and unsigned.

Spelling the registry out fixes both. `docker.io` is the reference form
oras maps to the `registry-1.docker.io` endpoint and to the
`https://index.docker.io/v1/` credential entry `docker/login-action`
writes, so the existing login still authenticates the attach.